### PR TITLE
add CGO_ENABLED=0 to build

### DIFF
--- a/build
+++ b/build
@@ -14,4 +14,4 @@ export GOBIN=${PWD}/bin
 export GOPATH=${PWD}/gopath
 
 echo "Building plugins"
-CGO_ENABLED=0 go install "$@" ${REPO_PATH}/multus
+CGO_ENABLED=0 go install "$@" -tags no_openssl ${REPO_PATH}/multus

--- a/build
+++ b/build
@@ -14,4 +14,4 @@ export GOBIN=${PWD}/bin
 export GOPATH=${PWD}/gopath
 
 echo "Building plugins"
-go install "$@" ${REPO_PATH}/multus
+CGO_ENABLED=0 go install "$@" ${REPO_PATH}/multus


### PR DESCRIPTION
Fixes break where libcrypto is being referenced:

> erroring out with: `/var/lib/cni/bin/multus: error while loading shared libraries: libcrypto.so.10: cannot open shared object file: No such file or directory` apparently the last working build was `4.0.0-0.nightly-2019-04-10-182914`