### PR TITLE
Bug 1732598: Adds one-shot CRIO restart

### DIFF
--- a/doc/how-to-use.md
+++ b/doc/how-to-use.md
@@ -541,3 +541,7 @@ In some cases, the original CNI configuration that the Multus configuration was 
 When using CRIO, you may need to restart CRIO to get the Multus configuration file to take -- this is rarely necessary.
 
     --restart-crio=false
+
+Additionally when using CRIO, you may wish to have the CNI config file that's used as the source for `--multus-conf-file=auto` renamed. This boolean option when set to true automatically renames the file with a `.old` suffix to the original filename.
+
+    --rename-conf-file=true

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -30,6 +30,7 @@ MULTUS_LOG_FILE=""
 OVERRIDE_NETWORK_NAME=false
 MULTUS_CLEANUP_CONFIG_ON_EXIT=false
 RESTART_CRIO=false
+CRIO_RESTARTED_ONCE=false
 
 # Give help text for parameters.
 function usage()
@@ -306,10 +307,20 @@ EOF
       echo $CONF > $CNI_CONF_DIR/00-multus.conf
       log "Config file created @ $CNI_CONF_DIR/00-multus.conf"
       echo $CONF
+      
+      # If we're not performing the cleanup on exit, we can safely rename the config file.
+      if [ "$MULTUS_CLEANUP_CONFIG_ON_EXIT" == false ]; then
+        mv ${MULTUS_AUTOCONF_DIR}/${MASTER_PLUGIN} ${MULTUS_AUTOCONF_DIR}/${MASTER_PLUGIN}.old
+        log "Original master file moved to ${MULTUS_AUTOCONF_DIR}/${MASTER_PLUGIN}.old"
+      fi
 
       if [ "$RESTART_CRIO" == true ]; then
-        log "Restarting crio"
-        systemctl restart crio
+        # Restart CRIO only once.
+        if [ "$CRIO_RESTARTED_ONCE" == false ]; then
+          log "Restarting crio"
+          systemctl restart crio
+          CRIO_RESTARTED_ONCE=true
+        fi
       fi
     fi
   done

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -31,6 +31,7 @@ OVERRIDE_NETWORK_NAME=false
 MULTUS_CLEANUP_CONFIG_ON_EXIT=false
 RESTART_CRIO=false
 CRIO_RESTARTED_ONCE=false
+RENAME_SOURCE_CONFIG_FILE=false
 
 # Give help text for parameters.
 function usage()
@@ -55,6 +56,7 @@ function usage()
     echo -e "\t--multus-log-file=$MULTUS_LOG_FILE (empty by default, used only with --multus-conf-file=auto)"
     echo -e "\t--override-network-name=false (used only with --multus-conf-file=auto)"
     echo -e "\t--cleanup-config-on-exit=false (used only with --multus-conf-file=auto)"
+    echo -e "\t--rename-conf-file=false (used only with --multus-conf-file=auto)"
     echo -e "\t--restart-crio=false (restarts CRIO after config file is generated)"
 }
 
@@ -120,6 +122,9 @@ while [ "$1" != "" ]; do
             ;;
         --restart-crio)
             RESTART_CRIO=$VALUE
+            ;;
+        --rename-conf-file)
+            RENAME_SOURCE_CONFIG_FILE=$VALUE
             ;;
         *)
             warn "unknown parameter \"$PARAM\""
@@ -309,7 +314,7 @@ EOF
       echo $CONF
       
       # If we're not performing the cleanup on exit, we can safely rename the config file.
-      if [ "$MULTUS_CLEANUP_CONFIG_ON_EXIT" == false ]; then
+      if [ "$RENAME_SOURCE_CONFIG_FILE" == true ]; then
         mv ${MULTUS_AUTOCONF_DIR}/${MASTER_PLUGIN} ${MULTUS_AUTOCONF_DIR}/${MASTER_PLUGIN}.old
         log "Original master file moved to ${MULTUS_AUTOCONF_DIR}/${MASTER_PLUGIN}.old"
       fi

--- a/images/multus-daemonset-crio.yml
+++ b/images/multus-daemonset-crio.yml
@@ -141,6 +141,7 @@ spec:
         - "--cni-bin-dir=/host/usr/libexec/cni"
         - "--multus-conf-file=auto"
         - "--override-network-name=true"
+        - "--rename-conf-file=true"
         resources:
           requests:
             cpu: "100m"


### PR DESCRIPTION
This add logic to restart CRIO once and only once when the Multus configuration is generated. This limits the impact of the CRIO restart, instead of having it restart every time the configuration is generated.

Additionally, this also folds in the upstream requirement to have the source configuration renamed, but, only in the case where we're using the watch loop (to use the original source configuration as a semaphore for network readiness). This rename cannot happen in that case (causes an infinite loop), but, is necessary when you're not using that functionality.