### PR TITLE
fix typo in images/entrypoint.sh

### DIFF
--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -231,7 +231,7 @@ if [ "$MULTUS_CONF_FILE" == "auto" ]; then
     if [ "$MASTER_PLUGIN" == "" ]; then
       if [ $tries -lt 600 ]; then
         if ! (($tries % 5)); then
-          log "Attemping to find master plugin configuration, attempt $tries"
+          log "Attempting to find master plugin configuration, attempt $tries"
         fi
         let "tries+=1"
         # See if the Multus configuration file exists, if it does then clean it up.


### PR DESCRIPTION
Noticed this typo in an error message in MCO repo.

See: https://github.com/openshift/machine-config-operator/pull/1105#issuecomment-528612719

cc: @dougbtv 