### PR TITLE
Bug 1725832: [Backport] Skips binary copy in entrypoint with new parameter

### DIFF
--- a/doc/how-to-use.md
+++ b/doc/how-to-use.md
@@ -549,3 +549,7 @@ Additionally when using CRIO, you may wish to have the CNI config file that's us
 When using `--multus-conf-file=auto` you may also care to specify a `binDir` in the configuration, this can be accomplished using the `--additional-bin-dir` option.
 
     --additional-bin-dir=/opt/multus/bin
+
+Sometimes, you may wish to not have the entrypoint copy the binary file onto the host. Potentially, you have another way to copy in a specific version of Multus, for example. By default, it's always copied, but you may disable the copy with:
+
+    --skip-multus-binary-copy=true

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -33,6 +33,7 @@ MULTUS_CLEANUP_CONFIG_ON_EXIT=false
 RESTART_CRIO=false
 CRIO_RESTARTED_ONCE=false
 RENAME_SOURCE_CONFIG_FILE=false
+SKIP_BINARY_COPY=false
 
 # Give help text for parameters.
 function usage()
@@ -50,6 +51,7 @@ function usage()
     echo -e "\t--cni-bin-dir=$CNI_BIN_DIR"
     echo -e "\t--multus-conf-file=$MULTUS_CONF_FILE"
     echo -e "\t--multus-bin-file=$MULTUS_BIN_FILE"
+    echo -e "\t--skip-multus-binary-copy=$SKIP_BINARY_COPY"
     echo -e "\t--multus-kubeconfig-file-host=$MULTUS_KUBECONFIG_FILE_HOST"
     echo -e "\t--namespace-isolation=$MULTUS_NAMESPACE_ISOLATION"
     echo -e "\t--multus-autoconfig-dir=$MULTUS_AUTOCONF_DIR (used only with --multus-conf-file=auto)"
@@ -131,6 +133,9 @@ while [ "$1" != "" ]; do
         --additional-bin-dir)
             ADDITIONAL_BIN_DIR=$VALUE
             ;;
+        --skip-multus-binary-copy)
+            SKIP_BINARY_COPY=$VALUE
+            ;;
         *)
             warn "unknown parameter \"$PARAM\""
             ;;
@@ -156,8 +161,13 @@ do
 done
 
 # Copy files into place and atomically move into final binary name
-cp -f $MULTUS_BIN_FILE $CNI_BIN_DIR/_multus
-mv -f $CNI_BIN_DIR/_multus $CNI_BIN_DIR/multus 
+if [ "$SKIP_BINARY_COPY" = false ]; then
+  cp -f $MULTUS_BIN_FILE $CNI_BIN_DIR/_multus
+  mv -f $CNI_BIN_DIR/_multus $CNI_BIN_DIR/multus
+else
+  log "Entrypoint skipped copying Multus binary."
+fi
+
 if [ "$MULTUS_CONF_FILE" != "auto" ]; then
   cp -f $MULTUS_CONF_FILE $CNI_CONF_DIR
 fi


### PR DESCRIPTION
Backport for 4.2.