### PR TITLE
Installs git via yum for ART builds

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -4,6 +4,7 @@ ADD . /usr/src/multus-cni
 WORKDIR /usr/src/multus-cni
 ENV CGO_ENABLED=1
 ENV GO111MODULE=off
+RUN yum install -y git
 RUN ./build && \
        cd /usr/src/multus-cni/bin
 WORKDIR /
@@ -18,6 +19,7 @@ RUN ./build && \
 
 WORKDIR /usr/src/multus-cni
 ENV GO111MODULE=off
+RUN yum install -y git
 RUN ./build && \
        cd /usr/src/multus-cni/bin
 WORKDIR /


### PR DESCRIPTION
Images in CI apparently mismatch what's used by the build system. Which were failing with a missing git a la:

```

--------------------------------------------------------------------------
The following logs are just the container build portion of the OSBS build:
--------------------------------------------------------------------------

imagebuilder build has begun; waiting for it to finish
--> FROM sha256:8afaf1806c79d7eb8c0ba75b9b141440b0d3137b9570e0fc4e9d696bbbfeed9f as rhel8
--> ADD atomic-reactor-repos/* '/etc/yum.repos.d/'
--> USER root
--> RUN mv -f /etc/yum.repos.d/ubi.repo /tmp || :
--> USER 0
--> ENV SOURCE_GIT_COMMIT=dc0b5c2a93d64fd75407beeb9fa5837bdf4ee2ce SOURCE_DATE_EPOCH=1573148656 BUILD_VERSION=v4.3.0 SOURCE_GIT_URL=https://github.com/openshift/multus-cni SOURCE_GIT_TAG=dc0b5c2a BUILD_RELEASE=201911080317
--> ADD . /usr/src/multus-cni
--> WORKDIR /usr/src/multus-cni
--> ENV CGO_ENABLED=1
--> ENV GO111MODULE=off
--> RUN ./build &&        cd /usr/src/multus-cni/bin
./build: line 23: git: command not found
running './build &&        cd /usr/src/multus-cni/bin' failed with exit code 127
2019-11-08 09:05:36,144 - atomic_reactor.plugin - ERROR - Build step plugin imagebuilder failed: image build failed (rc=1): running './build &&        cd /usr/src/multus-cni/bin' failed with exit code 127
```