### PR TITLE
Adds 45 second wait to let master plugin CNI configuration be regenerated

### DIFF
--- a/multus/multus.go
+++ b/multus/multus.go
@@ -48,12 +48,8 @@ var version = "master@git"
 var commit = "unknown commit"
 var date = "unknown date"
 
-var defaultReadinessBackoff = wait.Backoff{
-	Steps:    4,
-	Duration: 250 * time.Millisecond,
-	Factor:   4.0,
-	Jitter:   0.1,
-}
+var pollDuration = 1000 * time.Millisecond
+var pollTimeout = 45 * time.Second
 
 func printVersionString() string {
 	return fmt.Sprintf("multus-cni version:%s, commit:%s, date:%s",
@@ -371,7 +367,7 @@ func cmdAdd(args *skel.CmdArgs, exec invoke.Exec, kubeClient k8s.KubeClient) (cn
 		return nil, logging.Errorf("Multus: error getting k8s args: %v", err)
 	}
 
-	wait.ExponentialBackoff(defaultReadinessBackoff, func() (bool, error) {
+	wait.PollImmediate(pollDuration, pollTimeout, func() (bool, error) {
 		_, err := os.Stat(n.ReadinessIndicatorFile)
 		switch {
 		case err == nil:


### PR DESCRIPTION
To allow for a faster regenerating of the openshift-sdn configuration without causing an unnecessary exponential backoff for failed pods.