### PR TITLE
Bug 1835033: Logging improvement (UID, net-attach-def) / Backport to 4.4

### DIFF
--- a/k8sclient/k8sclient_test.go
+++ b/k8sclient/k8sclient_test.go
@@ -580,7 +580,7 @@ var _ = Describe("k8sclient operations", func() {
 		Expect(netConf.Delegates[0].Conf.Name).To(Equal("net2"))
 		Expect(netConf.Delegates[0].Conf.Type).To(Equal("mynet2"))
 
-		numK8sDelegates, _, err := TryLoadPodDelegates(k8sArgs, netConf, kubeClient)
+		numK8sDelegates, _, _, err := TryLoadPodDelegates(k8sArgs, netConf, kubeClient)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(numK8sDelegates).To(Equal(0))
 		Expect(netConf.Delegates[0].Conf.Name).To(Equal("net1"))
@@ -617,7 +617,7 @@ var _ = Describe("k8sclient operations", func() {
 		Expect(err).To(HaveOccurred())
 
 		netConf.ConfDir = "badfilepath"
-		_, _, err = TryLoadPodDelegates(k8sArgs, netConf, kubeClient)
+		_, _, _, err = TryLoadPodDelegates(k8sArgs, netConf, kubeClient)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -650,7 +650,7 @@ var _ = Describe("k8sclient operations", func() {
 		k8sArgs, err := GetK8sArgs(args)
 		Expect(err).NotTo(HaveOccurred())
 
-		numK8sDelegates, _, err := TryLoadPodDelegates(k8sArgs, netConf, kubeClient)
+		numK8sDelegates, _, _, err := TryLoadPodDelegates(k8sArgs, netConf, kubeClient)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(numK8sDelegates).To(Equal(0))
 		Expect(netConf.Delegates[0].Conf.Name).To(Equal("net1"))
@@ -685,7 +685,7 @@ var _ = Describe("k8sclient operations", func() {
 		k8sArgs, err := GetK8sArgs(args)
 		Expect(err).NotTo(HaveOccurred())
 
-		_, _, err = TryLoadPodDelegates(k8sArgs, netConf, nil)
+		_, _, _, err = TryLoadPodDelegates(k8sArgs, netConf, nil)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -717,12 +717,12 @@ var _ = Describe("k8sclient operations", func() {
 		k8sArgs, err := GetK8sArgs(args)
 		Expect(err).NotTo(HaveOccurred())
 
-		_, _, err = TryLoadPodDelegates(k8sArgs, netConf, nil)
+		_, _, _, err = TryLoadPodDelegates(k8sArgs, netConf, nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		// additionally, we expect the test to fail with no delegates, as at least one is always required.
 		netConf.Delegates = nil
-		_, _, err = TryLoadPodDelegates(k8sArgs, netConf, nil)
+		_, _, _, err = TryLoadPodDelegates(k8sArgs, netConf, nil)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -780,7 +780,7 @@ users:
 		k8sArgs, err := GetK8sArgs(args)
 		Expect(err).NotTo(HaveOccurred())
 
-		_, _, err = TryLoadPodDelegates(k8sArgs, netConf, nil)
+		_, _, _, err = TryLoadPodDelegates(k8sArgs, netConf, nil)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/multus/multus_test.go
+++ b/multus/multus_test.go
@@ -1169,7 +1169,7 @@ var _ = Describe("multus operations", func() {
 		_, err = cmdAdd(args, fExec, nil)
 		Expect(fExec.addIndex).To(Equal(2))
 		Expect(fExec.delIndex).To(Equal(2))
-		Expect(err).To(MatchError("Multus: error adding pod to network \"other1\": delegateAdd: error invoking DelegateAdd - \"other-plugin\": error in getting result from AddNetwork: expected plugin failure"))
+		Expect(err).To(MatchError("Multus: [/]: error adding container to network \"other1\": delegateAdd: error invoking DelegateAdd - \"other-plugin\": error in getting result from AddNetwork: expected plugin failure"))
 
 		// Cleanup default network file.
 		if _, errStat := os.Stat(configPath); errStat == nil {
@@ -1805,7 +1805,7 @@ var _ = Describe("multus operations", func() {
 		err = cmdDel(args, fExec, fKubeClient)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fExec.delIndex).To(Equal(len(fExec.plugins)))
-		Expect(fKubeClient.PodCount).To(Equal(3))
+		Expect(fKubeClient.PodCount).To(Equal(4))
 		Expect(fKubeClient.NetCount).To(Equal(1))
 	})
 
@@ -1886,7 +1886,7 @@ var _ = Describe("multus operations", func() {
 		err = cmdDel(args, fExec, fKubeClient)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fExec.delIndex).To(Equal(len(fExec.plugins)))
-		Expect(fKubeClient.PodCount).To(Equal(4))
+		Expect(fKubeClient.PodCount).To(Equal(5))
 		Expect(fKubeClient.NetCount).To(Equal(2))
 	})
 

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -149,6 +149,7 @@ func NewFakePod(name string, netAnnotation string, defaultNetAnnotation string) 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: "test",
+			UID:       "testUID",
 		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{

--- a/types/conf.go
+++ b/types/conf.go
@@ -97,6 +97,9 @@ func LoadDelegateNetConf(bytes []byte, net *NetworkSelectionElement, deviceID st
 	}
 
 	if net != nil {
+		if net.Name != "" {
+			delegateConf.Name = net.Name
+		}
 		if net.InterfaceRequest != "" {
 			delegateConf.IfnameRequest = net.InterfaceRequest
 		}
@@ -160,6 +163,7 @@ func CreateCNIRuntimeConf(args *skel.CmdArgs, k8sArgs *K8sArgs, ifName string, r
 		ContainerID: args.ContainerID,
 		NetNS:       args.Netns,
 		IfName:      ifName,
+		// NOTE: Verbose logging depends on this order, so please keep Args order.
 		Args: [][2]string{
 			{"IgnoreUnknown", string("true")},
 			{"K8S_POD_NAMESPACE", string(k8sArgs.K8S_POD_NAMESPACE)},

--- a/types/conf_test.go
+++ b/types/conf_test.go
@@ -368,17 +368,17 @@ var _ = Describe("config operations", func() {
     "args1": "val1"
 }`
 		type bridgeNetConf struct {
-			Name     string `json:"name"`
-			Type     string `json:"type"`
-			Args     struct {
+			Name string `json:"name"`
+			Type string `json:"type"`
+			Args struct {
 				CNI map[string]string `json:"cni"`
 			} `json:"args"`
 		}
 
-                err := json.Unmarshal([]byte(cniArgs), &args)
+		err := json.Unmarshal([]byte(cniArgs), &args)
 		Expect(err).NotTo(HaveOccurred())
-                net := &NetworkSelectionElement{
-			Name: "test-elem",
+		net := &NetworkSelectionElement{
+			Name:    "test-elem",
 			CNIArgs: &args,
 		}
 		delegateNetConf, err := LoadDelegateNetConf([]byte(conf), net, "")
@@ -404,17 +404,17 @@ var _ = Describe("config operations", func() {
     "args1": "val1a"
 }`
 		type bridgeNetConf struct {
-			Name     string `json:"name"`
-			Type     string `json:"type"`
-			Args     struct {
+			Name string `json:"name"`
+			Type string `json:"type"`
+			Args struct {
 				CNI map[string]string `json:"cni"`
 			} `json:"args"`
 		}
 
-                err := json.Unmarshal([]byte(cniArgs), &args)
+		err := json.Unmarshal([]byte(cniArgs), &args)
 		Expect(err).NotTo(HaveOccurred())
-                net := &NetworkSelectionElement{
-			Name: "test-elem",
+		net := &NetworkSelectionElement{
+			Name:    "test-elem",
 			CNIArgs: &args,
 		}
 		delegateNetConf, err := LoadDelegateNetConf([]byte(conf), net, "")
@@ -439,20 +439,20 @@ var _ = Describe("config operations", func() {
     "args1": "val1"
 }`
 		type bridgeNetConf struct {
-			Type     string `json:"type"`
-			Args     struct {
+			Type string `json:"type"`
+			Args struct {
 				CNI map[string]string `json:"cni"`
 			} `json:"args"`
 		}
 		type bridgeNetConfList struct {
-			Name     string `json:"name"`
+			Name    string           `json:"name"`
 			Plugins []*bridgeNetConf `json:"plugins"`
 		}
 
-                err := json.Unmarshal([]byte(cniArgs), &args)
+		err := json.Unmarshal([]byte(cniArgs), &args)
 		Expect(err).NotTo(HaveOccurred())
-                net := &NetworkSelectionElement{
-			Name: "test-elem",
+		net := &NetworkSelectionElement{
+			Name:    "test-elem",
 			CNIArgs: &args,
 		}
 		delegateNetConf, err := LoadDelegateNetConf([]byte(conf), net, "")

--- a/types/types.go
+++ b/types/types.go
@@ -94,6 +94,7 @@ type NetworkStatus struct {
 type DelegateNetConf struct {
 	Conf                types.NetConf
 	ConfList            types.NetConfList
+	Name                string
 	IfnameRequest       string          `json:"ifnameRequest,omitempty"`
 	MacRequest          string          `json:"macRequest,omitempty"`
 	IPRequest           []string        `json:"ipRequest,omitempty"`


### PR DESCRIPTION
This change adds pod UID and net-attach-def name in verbose log
and sends kubernetes event when net-attach-def is not found.