### PR TITLE
Bug 1878163: Updating multus-cni builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -9,7 +9,7 @@ RUN ./build && \
        cd /usr/src/multus-cni/bin
 WORKDIR /
 
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-7-golang-openshift-4.6 as rhel7
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-7-golang-1.15-openshift-4.6 AS rhel7
 ADD . /usr/src/multus-cni
 WORKDIR /usr/src/multus-cni
 ENV CGO_ENABLED=1


### PR DESCRIPTION
Updating multus-cni builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/990044f295fb1d5e238823902962dbcfa1c041c9/images/multus-cni.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.
