### PR TITLE
Bug 1905230: Multus should exit zero on DEL when cache file is missing [backport 4.6]

### DIFF
--- a/multus/multus.go
+++ b/multus/multus.go
@@ -758,7 +758,10 @@ func cmdDel(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) er
 				logging.Errorf("Multus: failed to get delegates: %v, but continue to delete clusterNetwork", err)
 			}
 		} else {
-			return cmdErr(k8sArgs, "error reading the delegates: %v", err)
+			// The options to continue with a delete have been exhausted (cachefile + API query didn't work)
+			// We cannot exit with an error as this may cause a sandbox to never get deleted.
+			logging.Errorf("Multus: failed to get the cached delegates file: %v, cannot properly delete", err)
+			return nil
 		}
 	} else {
 		defer os.Remove(path)


### PR DESCRIPTION
Otherwise, this can cause a pod to not be fully deleted, its sandbox may remain as the DEL continues to be retried due to exiting non-zero every time.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1900835