### PR TITLE
crio: mount /run rslave

### DIFF
--- a/deployments/multus-daemonset-crio.yml
+++ b/deployments/multus-daemonset-crio.yml
@@ -191,6 +191,7 @@ spec:
         volumeMounts:
         - name: run
           mountPath: /run
+          mountPropagation: HostToContainer
         - name: cni
           mountPath: /host/etc/cni/net.d
         - name: cnibin


### PR DESCRIPTION
to prevent "unknown FS magic on "/var/run/netns/*": 1021994" errors

see https://github.com/containernetworking/plugins/issues/69 and https://github.com/openshift/cluster-network-operator/pull/669

related to https://bugzilla.redhat.com/show_bug.cgi?id=2057618

Signed-off-by: Peter Hunt <pehunt@redhat.com>