### PR TITLE
OCPBUGS-8672: SNO: Pods fail to delete, Multus: failed to open netns [backport 4.10]

### DIFF
--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -773,7 +773,7 @@ func CmdDel(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) er
 		if ok {
 			logging.Debugf("CmdDel: WARNING netns may not exist, netns: %s, err: %s", args.Netns, err)
 		} else {
-			return cmdErr(nil, "failed to open netns %q: %v", netns, err)
+			logging.Debugf("CmdDel: WARNING failed to open netns %q: %v", netns, err)
 		}
 	}
 


### PR DESCRIPTION
only warn when netns can't be opened

Co-authored-by: dougbtv <dosmith@redhat.com>