### PR TITLE
Suppress uid mismatch error/warning in case of static pod

### DIFF
--- a/pkg/k8sclient/k8sclient.go
+++ b/pkg/k8sclient/k8sclient.go
@@ -120,7 +120,7 @@ func SetNetworkStatus(client *ClientInfo, k8sArgs *types.K8sArgs, netStatus []ne
 		return logging.Errorf("SetNetworkStatus: failed to query the pod %v in out of cluster comm: %v", podName, err)
 	}
 
-	if podUID != "" && string(pod.UID) != podUID {
+	if podUID != "" && string(pod.UID) != podUID && !IsStaticPod(pod) {
 		return logging.Errorf("SetNetworkStatus: expected pod %s/%s UID %q but got %q from Kube API", podNamespace, podName, podUID, pod.UID)
 	}
 
@@ -615,4 +615,17 @@ func tryLoadK8sPodDefaultNetwork(kubeClient *ClientInfo, pod *v1.Pod, conf *type
 	delegate.MasterPlugin = true
 
 	return delegate, nil
+}
+
+// ConfigSourceAnnotationKey specifies kubernetes annotation, defined in k8s.io/kubernetes/pkg/kubelet/types
+const ConfigSourceAnnotationKey = "kubernetes.io/config.source"
+
+// IsStaticPod returns true if the pod is static pod.
+func IsStaticPod(pod *v1.Pod) bool {
+	if pod.Annotations != nil {
+		if source, ok := pod.Annotations[ConfigSourceAnnotationKey]; ok == true {
+			return source != "api"
+		}
+	}
+	return false
 }

--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -551,7 +551,8 @@ func getPod(kubeClient *k8s.ClientInfo, k8sArgs *types.K8sArgs, warnOnly bool) (
 		}
 	}
 
-	if podUID != "" && string(pod.UID) != podUID {
+	// In case of static pod, UID through kube api is different because of mirror pod, hence it is expected.
+	if podUID != "" && string(pod.UID) != podUID && !k8s.IsStaticPod(pod) {
 		msg := fmt.Sprintf("expected pod UID %q but got %q from Kube API", podUID, pod.UID)
 		if warnOnly {
 			// On CNI DEL we just operate on the cache when these mismatch, we don't error out.


### PR DESCRIPTION
In static pod case, kube api returns mirror pod UID hence uid must be mismatched. This fix suppress error/warning message in such case.

Fix #773

(cherry picked from commit 2e474f4c95a60ec633738654e2f61ec8a471e500)