### PR TITLE
OCPBUGS-7844: Fix multus to support CNI plugin which does not create interface [backport 4.12]

### DIFF
--- a/pkg/multus/multus_test.go
+++ b/pkg/multus/multus_test.go
@@ -339,6 +339,67 @@ var _ = Describe("multus operations cniVersion 0.2.0 config", func() {
 		Expect(fExec.delIndex).To(Equal(len(fExec.plugins)))
 	})
 
+	It("executes delegates (plugin without interface)", func() {
+		args := &skel.CmdArgs{
+			ContainerID: "123456789",
+			Netns:       testNS.Path(),
+			IfName:      "eth0",
+			StdinData: []byte(`{
+			    "name": "node-cni-network",
+			    "type": "multus",
+			    "defaultnetworkfile": "/tmp/foo.multus.conf",
+			    "defaultnetworkwaitseconds": 3,
+			    "delegates": [{
+			        "name": "weave1",
+			        "cniVersion": "0.2.0",
+			        "type": "weave-net"
+			    },{
+			        "name": "other1",
+			        "cniVersion": "0.2.0",
+			        "type": "other-plugin"
+			    }]
+			}`),
+		}
+
+		logging.SetLogLevel("verbose")
+
+		fExec := newFakeExec()
+		expectedResult1 := &types020.Result{
+			CNIVersion: "0.2.0",
+			IP4: &types020.IPConfig{
+				IP: *testhelpers.EnsureCIDR("1.1.1.2/24"),
+			},
+		}
+		expectedConf1 := `{
+			    "name": "weave1",
+			    "cniVersion": "0.2.0",
+			    "type": "weave-net"
+			}`
+		fExec.addPlugin020(nil, "eth0", expectedConf1, expectedResult1, nil)
+
+		// other1 just returns empty result
+		expectedResult2 := &types020.Result{
+			CNIVersion: "0.2.0",
+		}
+		expectedConf2 := `{
+			    "name": "other1",
+			    "cniVersion": "0.2.0",
+			    "type": "other-plugin"
+			}`
+		fExec.addPlugin020(nil, "net1", expectedConf2, expectedResult2, nil)
+
+		result, err := CmdAdd(args, fExec, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(fExec.addIndex).To(Equal(len(fExec.plugins)))
+		r := result.(*types020.Result)
+		// plugin 1 is the masterplugin
+		Expect(reflect.DeepEqual(r, expectedResult1)).To(BeTrue())
+
+		err = CmdDel(args, fExec, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(fExec.delIndex).To(Equal(len(fExec.plugins)))
+	})
+
 	It("executes delegates given faulty namespace", func() {
 		args := &skel.CmdArgs{
 			ContainerID: "123456789",


### PR DESCRIPTION
This change fixes multus to support CNI plugin which does not create any interface and return empty result. Some CNI plugin may do network configuration change only and does not create any interface and return empty CNI result. Current multus assumes that CNI config always creates some interfaces hence above CNI plugin is out of assumption and multus may not work with such plugins.