### PR TITLE
Add rhel9 binary for multus

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,4 +1,14 @@
 # This dockerfile is specific to building Multus for OpenShift
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-4.13 AS rhel9
+ADD . /usr/src/multus-cni
+WORKDIR /usr/src/multus-cni
+ENV CGO_ENABLED=1
+ENV GO111MODULE=off
+ENV VERSION=rhel9 COMMIT=unset
+RUN ./hack/build-go.sh && \
+       cd /usr/src/multus-cni/bin
+WORKDIR /
+
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.13 AS rhel8
 ADD . /usr/src/multus-cni
 WORKDIR /usr/src/multus-cni
@@ -9,28 +19,14 @@ RUN ./hack/build-go.sh && \
        cd /usr/src/multus-cni/bin
 WORKDIR /
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.13 AS rhel7
-ADD . /usr/src/multus-cni
-WORKDIR /usr/src/multus-cni
-ENV CGO_ENABLED=1
-ENV GO111MODULE=off
-RUN ./hack/build-go.sh && \
-       cd /usr/src/multus-cni/bin
-
-WORKDIR /usr/src/multus-cni
-ENV GO111MODULE=off
-RUN ./hack/build-go.sh && \
-       cd /usr/src/multus-cni/bin 
-RUN ls -lathr /usr/src/multus-cni/bin
-WORKDIR /
 
 FROM registry.ci.openshift.org/ocp/4.13:base
 RUN mkdir -p /usr/src/multus-cni/images && \
        mkdir -p /usr/src/multus-cni/bin && \
-       mkdir -p /usr/src/multus-cni/rhel7/bin && \
+       mkdir -p /usr/src/multus-cni/rhel9/bin && \
        mkdir -p /usr/src/multus-cni/rhel8/bin
-COPY --from=rhel7 /usr/src/multus-cni/bin /usr/src/multus-cni/rhel7/bin
-COPY --from=rhel8 /usr/src/multus-cni/bin /usr/src/multus-cni/bin
+COPY --from=rhel9 /usr/src/multus-cni/bin /usr/src/multus-cni/rhel9/bin
+COPY --from=rhel9 /usr/src/multus-cni/bin /usr/src/multus-cni/bin
 COPY --from=rhel8 /usr/src/multus-cni/bin /usr/src/multus-cni/rhel8/bin
 ADD ./images/entrypoint.sh /
 

--- a/images/Dockerfile.openshift
+++ b/images/Dockerfile.openshift
@@ -1,4 +1,14 @@
 # This dockerfile is specific to building Multus for OpenShift
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-4.13 AS rhel9
+ADD . /usr/src/multus-cni
+WORKDIR /usr/src/multus-cni
+ENV CGO_ENABLED=1
+ENV GO111MODULE=off
+ENV VERSION=rhel9 COMMIT=unset
+RUN ./hack/build-go.sh && \
+       cd /usr/src/multus-cni/bin
+WORKDIR /
+
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.13 AS rhel8
 ADD . /usr/src/multus-cni
 WORKDIR /usr/src/multus-cni
@@ -9,29 +19,15 @@ RUN ./hack/build-go.sh && \
        cd /usr/src/multus-cni/bin
 WORKDIR /
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.13 AS rhel7
-ADD . /usr/src/multus-cni
-WORKDIR /usr/src/multus-cni
-ENV CGO_ENABLED=1
-ENV GO111MODULE=off
-RUN ./hack/build-go.sh && \
-       cd /usr/src/multus-cni/bin
 
-WORKDIR /usr/src/multus-cni
-ENV GO111MODULE=off
-RUN ./hack/build-go.sh && \
-       cd /usr/src/multus-cni/bin 
-RUN ls -lathr /usr/src/multus-cni/bin/multus
-WORKDIR /
-
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.13
+FROM registry.ci.openshift.org/ocp/4.13:base
 RUN mkdir -p /usr/src/multus-cni/images && \
        mkdir -p /usr/src/multus-cni/bin && \
-       mkdir -p /usr/src/multus-cni/rhel7/bin && \
+       mkdir -p /usr/src/multus-cni/rhel9/bin && \
        mkdir -p /usr/src/multus-cni/rhel8/bin
-COPY --from=rhel7 /usr/src/multus-cni/bin/* /usr/src/multus-cni/rhel7/bin
-COPY --from=rhel8 /usr/src/multus-cni/bin/* /usr/src/multus-cni/bin
-COPY --from=rhel8 /usr/src/multus-cni/bin/* /usr/src/multus-cni/rhel8/bin
+COPY --from=rhel9 /usr/src/multus-cni/bin /usr/src/multus-cni/rhel9/bin
+COPY --from=rhel9 /usr/src/multus-cni/bin /usr/src/multus-cni/bin
+COPY --from=rhel8 /usr/src/multus-cni/bin /usr/src/multus-cni/rhel8/bin
 ADD ./images/entrypoint.sh /
 
 LABEL io.k8s.display-name="Multus CNI" \


### PR DESCRIPTION
Now that the binary is being dynamically compiled downstream, the binary must match the RHEL version of RHCOS because it is copied to the host.