### PR TITLE
OCPBUGS-22461: fix multiple default gw

### DIFF
--- a/pkg/types/conf.go
+++ b/pkg/types/conf.go
@@ -570,16 +570,14 @@ func CheckGatewayConfig(delegates []*DelegateNetConf) error {
 
 	// set filter flag for each delegate
 	for i, delegate := range delegates {
-		// no GatewayRequest
-		if delegate.GatewayRequest == nil {
-			delegates[i].IsFilterV4Gateway = true
-			delegates[i].IsFilterV6Gateway = true
-		} else {
+		delegates[i].IsFilterV4Gateway = true
+		delegates[i].IsFilterV6Gateway = true
+		if delegate.GatewayRequest != nil {
 			for _, gw := range *delegate.GatewayRequest {
 				if gw.To4() != nil {
-					delegates[i].IsFilterV6Gateway = true
+					delegates[i].IsFilterV4Gateway = false
 				} else {
-					delegates[i].IsFilterV4Gateway = true
+					delegates[i].IsFilterV6Gateway = false
 				}
 			}
 		}


### PR DESCRIPTION
when the configuration specifies both an IPv4 and IPv6 default route, the IsFilterV4Gateway and IsFilterV6Gateway flags should both be false, to allow the gateway configuration.
The logic in CheckGatewayConfig would do the inverse, setting both to true in case of both IPv4 and IPv6 gateway.

Fixes: d52f2b6a ("Update libcni cache when default-route net selection is used")