### PR TITLE
OCPBUGS-26397: Revert #205 "Adds a wait on unix socket readiness"

### DIFF
--- a/cmd/cert-approver/main.go
+++ b/cmd/cert-approver/main.go
@@ -73,15 +73,15 @@ var (
 	// ControllerName provides controller name
 	ControllerName = "csr-approver"
 	// NamePrefix specifies which name in certification request should be target to approve
-	NamePrefix = "system:multus"
+	NamePrefix     = "system:multus"
 	// Organization specifies which org in certification request should be target to approve
-	Organization = []string{"system:multus"}
+	Organization   = []string{"system:multus"}
 	// Groups specifies which group in certification request should be target to approve
-	Groups = sets.New[string]("system:nodes", "system:multus", "system:authenticated")
+	Groups         = sets.New[string]("system:nodes", "system:multus", "system:authenticated")
 	// UserPrefixes specifies which name prefix in certification request should be target to approve
-	UserPrefixes = sets.New[string]("system:node", NamePrefix)
+	UserPrefixes   = sets.New[string]("system:node", NamePrefix)
 	// Usages specifies which usage in certification request should be target to approve
-	Usages = sets.New[certificatesv1.KeyUsage](
+	Usages         = sets.New[certificatesv1.KeyUsage](
 		certificatesv1.UsageDigitalSignature,
 		certificatesv1.UsageClientAuth)
 )

--- a/cmd/multus-daemon/main.go
+++ b/cmd/multus-daemon/main.go
@@ -28,6 +28,7 @@ import (
 	"path/filepath"
 	"sync"
 	"syscall"
+	"time"
 
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 
@@ -112,7 +113,7 @@ func main() {
 
 	// Wait until daemon ready
 	logging.Verbosef("API readiness check")
-	if api.WaitUntilAPIReady(daemonConf.SocketDir) != nil {
+	if waitUntilAPIReady(daemonConf.SocketDir) != nil {
 		logging.Panicf("failed to ready multus-daemon socket: %v", err)
 		os.Exit(1)
 	}
@@ -137,6 +138,16 @@ func main() {
 
 	wg.Wait()
 	logging.Verbosef("multus daemon is exited")
+}
+
+func waitUntilAPIReady(socketPath string) error {
+	apiReadyPollDuration := 100 * time.Millisecond
+	apiReadyPollTimeout := 1000 * time.Millisecond
+
+	return utilwait.PollImmediate(apiReadyPollDuration, apiReadyPollTimeout, func() (bool, error) {
+		_, err := api.DoCNI(api.GetAPIEndpoint(api.MultusHealthAPIEndpoint), nil, api.SocketPath(socketPath))
+		return err == nil, nil
+	})
 }
 
 func startMultusDaemon(ctx context.Context, daemonConfig *srv.ControllerNetConf, ignoreReadinessIndicator bool) error {

--- a/cmd/thin_entrypoint/main_test.go
+++ b/cmd/thin_entrypoint/main_test.go
@@ -1,14 +1,12 @@
 package main
 
-// disable dot-imports only for testing
-//revive:disable:dot-imports
 import (
 	"fmt"
 	"os"
 	"testing"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:golint
-	. "github.com/onsi/gomega"    //nolint:golint
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 func TestThinEntrypoint(t *testing.T) {

--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -22,17 +22,9 @@ import (
 	"net"
 	"net/http"
 	"strings"
-	"time"
-
-	utilwait "k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
-	// APIReadyPollDuration specifies duration for API readiness check polling
-	APIReadyPollDuration = 100 * time.Millisecond
-	// APIReadyPollTimeout specifies timeout for API readiness check polling
-	APIReadyPollTimeout = 60000 * time.Millisecond
-
 	// MultusCNIAPIEndpoint is an endpoint for multus CNI request (for multus-shim)
 	MultusCNIAPIEndpoint = "/cni"
 	// MultusDelegateAPIEndpoint is an endpoint for multus delegate request (for hotplug)
@@ -95,12 +87,4 @@ func CreateDelegateRequest(cniCommand, cniContainerID, cniNetNS, cniIFName, podN
 		Config:              cniConfig,
 		InterfaceAttributes: interfaceAttributes,
 	}
-}
-
-// WaitUntilAPIReady checks API readiness
-func WaitUntilAPIReady(socketPath string) error {
-	return utilwait.PollImmediate(APIReadyPollDuration, APIReadyPollTimeout, func() (bool, error) {
-		_, err := DoCNI(GetAPIEndpoint(MultusHealthAPIEndpoint), nil, SocketPath(socketPath))
-		return err == nil, nil
-	})
 }

--- a/pkg/server/api/shim.go
+++ b/pkg/server/api/shim.go
@@ -24,8 +24,6 @@ import (
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 
 	"gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/logging"
-
-	utilwait "k8s.io/apimachinery/pkg/util/wait"
 )
 
 // ShimNetConf for the SHIM cni config file written in json
@@ -79,21 +77,12 @@ func postRequest(args *skel.CmdArgs) (*Response, string, error) {
 		return nil, "", fmt.Errorf("invalid CNI configuration passed to multus-shim: %w", err)
 	}
 
-	// check API readiness
-	if err := WaitUntilAPIReady(multusShimConfig.MultusSocketDir); err != nil {
-		return nil, multusShimConfig.CNIVersion, err
-	}
-
 	cniRequest, err := newCNIRequest(args)
 	if err != nil {
 		return nil, multusShimConfig.CNIVersion, err
 	}
 
-	var body []byte
-	err = utilwait.PollImmediate(APIReadyPollDuration, APIReadyPollTimeout, func() (bool, error) {
-		body, err = DoCNI("http://dummy/cni", cniRequest, SocketPath(multusShimConfig.MultusSocketDir))
-		return err == nil, nil
-	})
+	body, err := DoCNI("http://dummy/cni", cniRequest, SocketPath(multusShimConfig.MultusSocketDir))
 	if err != nil {
 		return nil, multusShimConfig.CNIVersion, err
 	}

--- a/pkg/server/config/config_suite_test.go
+++ b/pkg/server/config/config_suite_test.go
@@ -14,8 +14,6 @@
 
 package config
 
-// disable dot-imports only for testing
-//revive:disable:dot-imports
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/pkg/server/config/generator_test.go
+++ b/pkg/server/config/generator_test.go
@@ -14,8 +14,6 @@
 
 package config
 
-// disable dot-imports only for testing
-//revive:disable:dot-imports
 import (
 	"encoding/json"
 	"fmt"

--- a/pkg/server/config/manager_test.go
+++ b/pkg/server/config/manager_test.go
@@ -14,8 +14,6 @@
 
 package config
 
-// disable dot-imports only for testing
-//revive:disable:dot-imports
 import (
 	"context"
 	"encoding/json"


### PR DESCRIPTION

Reverts #205 ; tracked by https://issues.redhat.com/browse/OCPBUGS-26397

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

Multiple payload failures due to multus-cni CmdAdd timeouts for SND

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
/payload-job periodic-ci-openshift-release-master-nightly-4.16-e2e-aws-sdn-upgrade
```

CC: @dougbtv

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
