### PR TITLE
OCPBUGS-29624: Revert #216 "OCPBUGS-27429: Reload bootstrap kubeconfig if cert mgr failed to load valid certs"

### DIFF
--- a/pkg/k8sclient/kubeconfig.go
+++ b/pkg/k8sclient/kubeconfig.go
@@ -22,12 +22,10 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"strings"
 	"time"
 
 	certificatesv1 "k8s.io/api/certificates/v1"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -89,28 +87,8 @@ func PerNodeK8sClient(nodeName, bootstrapKubeconfigFile string, certDuration tim
 	// https://github.com/kubernetes/kubernetes/blob/068ee321bc7bfe1c2cefb87fb4d9e5deea84fbc8/cmd/kubelet/app/server.go#L953-L963
 	newClientsetFn := func(current *tls.Certificate) (kubernetes.Interface, error) {
 		cfg := bootstrapKubeconfig
-
-		// validate the kubeconfig
-		tempClient, err := kubernetes.NewForConfig(cfg)
-		if err != nil {
-			logging.Errorf("failed to read kubeconfig from cert manager: %v", err)
-		} else {
-			_, err := tempClient.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{})
-			// tls unknown authority error is unrecoverable error with retry
-			if err != nil {
-				if strings.Contains(err.Error(), "x509: certificate signed by unknown authority") {
-					logging.Verbosef("cert mgr gets invalid config. rebuild from bootstrap kubeconfig")
-					// reload and use bootstrapKubeconfig again
-					newBootstrapKubeconfig, _ := clientcmd.BuildConfigFromFlags("", bootstrapKubeconfigFile)
-					cfg = newBootstrapKubeconfig
-				} else {
-					logging.Errorf("failed to list pods with new certs: %v", err)
-				}
-			}
-
-			if current != nil {
-				cfg = config
-			}
+		if current != nil {
+			cfg = config
 		}
 		return kubernetes.NewForConfig(cfg)
 	}


### PR DESCRIPTION

Reverts #216 ; tracked by OCPBUGS-29624

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

Test revert only, the linked bug outlines the problem we're facing, revert is just a test to see if we get consistent success or not.

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
/payload-job periodic-ci-openshift-release-master-nightly-4.16-e2e-metal-ipi-ovn-ipv6
```

CC: @s1061123

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
