### PR TITLE
OCPBUGS-28230: enforce termination message policy on all platform pods

### DIFF
--- a/deployments/multus-daemonset-crio.yml
+++ b/deployments/multus-daemonset-crio.yml
@@ -197,6 +197,7 @@ spec:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: run
           mountPath: /run

--- a/deployments/multus-daemonset-thick.yml
+++ b/deployments/multus-daemonset-thick.yml
@@ -165,6 +165,7 @@ spec:
               memory: "50Mi"
           securityContext:
             privileged: true
+          terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - name: cni
               mountPath: /host/etc/cni/net.d
@@ -208,6 +209,7 @@ spec:
               memory: "15Mi"
           securityContext:
             privileged: true
+          terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - name: cnibin
               mountPath: /host/opt/cni/bin

--- a/deployments/multus-daemonset.yml
+++ b/deployments/multus-daemonset.yml
@@ -194,6 +194,7 @@ spec:
             memory: "50Mi"
         securityContext:
           privileged: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: cni
           mountPath: /host/etc/cni/net.d
@@ -214,6 +215,7 @@ spec:
               memory: "15Mi"
           securityContext:
             privileged: true
+          terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - name: cnibin
               mountPath: /host/opt/cni/bin


### PR DESCRIPTION
This will include the last few log lines on container crashes to assist in debugging.