### PR TITLE
OCPBUGS-33559: Thick plugin should not wait for API readiness on CNI DEL

### DIFF
--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -104,3 +104,12 @@ func WaitUntilAPIReady(socketPath string) error {
 		return err == nil, nil
 	})
 }
+
+// CheckAPIReadyNow checks API readiness once
+func CheckAPIReadyNow(socketPath string) error {
+	_, err := DoCNI(GetAPIEndpoint(MultusHealthAPIEndpoint), nil, SocketPath(socketPath))
+	if err != nil {
+		return fmt.Errorf("CheckAPIReadyNow: Daemon not reachable over socketfile: %v", err)
+	}
+	return nil
+}


### PR DESCRIPTION
This modifies the behavior on CNI DEL for the thick plugin to just check once for API readiness, as opposed to waiting.

(cherry picked from commit 181f56f026078cb58871d7fe3002ffadde8c256c)