### PR TITLE
OCPBUGS-33478: Fix CNI cache update function to prevent nil access

### DIFF
--- a/pkg/netutils/netutils.go
+++ b/pkg/netutils/netutils.go
@@ -206,7 +206,12 @@ func deleteDefaultGWResult(result map[string]interface{}, ipv4, ipv6 bool) (map[
 			return nil, err
 		}
 	}
-	result["routes"] = routes
+
+	if len(routes) == 0 {
+		delete(result, "routes")
+	} else {
+		result["routes"] = routes
+	}
 
 	return result, nil
 }

--- a/pkg/netutils/netutils_test.go
+++ b/pkg/netutils/netutils_test.go
@@ -639,6 +639,39 @@ var _ = Describe("netutil cnicache function testing", func() {
 			Expect(len(result.Result.Routes)).To(Equal(5))
 		})
 
+		It("verify ipv4 default gateway from single routes is removed/added from CNI 1.0.0 results", func() {
+			origResult := []byte(`{
+  "kind": "cniCacheV1",
+  "result": {
+    "cniVersion": "1.0.0",
+    "dns": {},
+    "interfaces": [
+      {
+        "mac": "0a:c2:e6:3d:45:17",
+        "name": "net1",
+        "sandbox": "/run/netns/bb74fcb9-989a-4589-b2df-ddd0384a8ee5"
+      }
+    ],
+    "ips": [
+      {
+        "address": "10.1.1.103/24",
+        "interface": 0
+      }
+    ],
+    "routes": [
+      {
+        "dst": "0.0.0.0/0",
+        "gw": "10.1.1.1"
+      }
+    ]
+  }
+}`)
+			newResult1, err := deleteDefaultGWCacheBytes(origResult, true, false)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = addDefaultGWCacheBytes(newResult1, []net.IP{net.ParseIP("10.1.1.1")})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
 		It("verify ipv6 default gateway is removed from CNI 1.0.0 results", func() {
 			origResult := []byte(`{
   "kind": "cniCacheV1",
@@ -709,6 +742,39 @@ var _ = Describe("netutil cnicache function testing", func() {
 			result := CNICacheResult100{}
 			Expect(json.Unmarshal(newResult, &result)).NotTo(HaveOccurred())
 			Expect(len(result.Result.Routes)).To(Equal(5))
+		})
+
+		It("verify ipv6 default gateway from single routes is removed/added from CNI 1.0.0 results", func() {
+			origResult := []byte(`{
+  "kind": "cniCacheV1",
+  "result": {
+    "cniVersion": "1.0.0",
+    "dns": {},
+    "interfaces": [
+      {
+        "mac": "0a:c2:e6:3d:45:17",
+        "name": "net1",
+        "sandbox": "/run/netns/bb74fcb9-989a-4589-b2df-ddd0384a8ee5"
+      }
+    ],
+    "ips": [
+      {
+        "address": "10::1:1:103/64",
+        "interface": 0
+      }
+    ],
+    "routes": [
+      {
+        "dst": "::0/0",
+        "gw": "10::1:1:1"
+      }
+    ]
+  }
+}`)
+			newResult1, err := deleteDefaultGWCacheBytes(origResult, false, true)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = addDefaultGWCacheBytes(newResult1, []net.IP{net.ParseIP("10::1:1:1")})
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("verify ipv4 default gateway is added to CNI 0.1.0/0.2.0 results without routes", func() {


### PR DESCRIPTION
deleteDefaultGWResult() may create 'routes:null' in CNI cache file and it causes nil pointer access at addDefaultGWCacheBytes(). This code change prevents deleteDefaultGWResult() to generate 'routes:null' in cache file.