### PR TITLE
OKD-218: install util-linux

### DIFF
--- a/Dockerfile.microshift
+++ b/Dockerfile.microshift
@@ -9,7 +9,8 @@ RUN ./hack/build-go.sh
 WORKDIR /
 
 FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
-RUN mkdir -p /usr/src/multus-cni/bin
+RUN dnf install -y util-linux && dnf clean all && \
+    mkdir -p /usr/src/multus-cni/bin
 COPY --from=rhel9 \
   /usr/src/multus-cni/bin/thin_entrypoint \
   /usr/src/multus-cni/bin/multus \

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -20,7 +20,8 @@ RUN ./hack/build-go.sh && \
 WORKDIR /
 
 FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
-RUN mkdir -p /usr/src/multus-cni/images && \
+RUN dnf install -y util-linux && dnf clean all && \
+       mkdir -p /usr/src/multus-cni/images && \
        mkdir -p /usr/src/multus-cni/bin && \
        mkdir -p /usr/src/multus-cni/rhel9/bin && \
        mkdir -p /usr/src/multus-cni/rhel8/bin


### PR DESCRIPTION
Similar to openshift/egress-router-cni#82. Needed for OKD installs to succeed. https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-master-okd-scos-4.16-e2e-aws-ovn/1798613975458385920/artifacts/e2e-aws-ovn/gather-extra/artifacts/pods.json shows the failing containers with this error.