### PR TITLE
always attempt a live pod get on miss to confirm its really not there

### DIFF
--- a/pkg/k8sclient/k8sclient.go
+++ b/pkg/k8sclient/k8sclient.go
@@ -82,6 +82,10 @@ func (c *ClientInfo) GetPod(namespace, name string) (*v1.Pod, error) {
 	return c.Client.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
 
+func (c *ClientInfo) GetPodLive(namespace, name string) (*v1.Pod, error) {
+	return c.Client.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
 // DeletePod deletes a pod from kubernetes
 func (c *ClientInfo) DeletePod(namespace, name string) error {
 	return c.Client.CoreV1().Pods(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})

--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -555,7 +555,7 @@ func GetPod(kubeClient *k8s.ClientInfo, k8sArgs *types.K8sArgs, isDel bool) (*v1
 		// Try one more time to get the pod directly from the apiserver;
 		// TODO: figure out why static pods don't show up via the informer
 		// and always hit this case.
-		pod, err = kubeClient.GetPod(podNamespace, podName)
+		pod, err = kubeClient.GetPodLive(podNamespace, podName)
 		if err != nil {
 			return nil, cmdErr(k8sArgs, "error waiting for pod: %v", err)
 		}


### PR DESCRIPTION
This makes sure that stale caches never result in NotFound errors.

/assign @jluhrsen 