### PR TITLE
OCPBUGS-42236: (CARRY) Graceful shutdown functionality for multus daemon

### DIFF
--- a/deployments/multus-daemonset-crio.yml
+++ b/deployments/multus-daemonset-crio.yml
@@ -208,7 +208,7 @@ spec:
           mountPath: /host/usr/libexec/cni
         - name: multus-cfg
           mountPath: /tmp/multus-conf
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: run
           hostPath:

--- a/deployments/multus-daemonset-thick.yml
+++ b/deployments/multus-daemonset-thick.yml
@@ -215,7 +215,7 @@ spec:
             - name: cnibin
               mountPath: /host/opt/cni/bin
               mountPropagation: Bidirectional
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: cni
           hostPath:

--- a/deployments/multus-daemonset.yml
+++ b/deployments/multus-daemonset.yml
@@ -220,7 +220,7 @@ spec:
             - name: cnibin
               mountPath: /host/opt/cni/bin
               mountPropagation: Bidirectional
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: cni
           hostPath:

--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -41,6 +41,9 @@ const (
 
 	// MultusHealthAPIEndpoint is an endpoint API clients can query to know if they can communicate w/ multus server
 	MultusHealthAPIEndpoint = "/healthz"
+
+	// MultusReadyAPIEndpoint is like health, but starts returning status 500 once a sig-term is received.
+	MultusReadyAPIEndpoint = "/readyz"
 )
 
 // DoCNI sends a CNI request to the CNI server via JSON + HTTP over a root-owned unix socket,
@@ -100,7 +103,7 @@ func CreateDelegateRequest(cniCommand, cniContainerID, cniNetNS, cniIFName, podN
 // WaitUntilAPIReady checks API readiness
 func WaitUntilAPIReady(socketPath string) error {
 	return utilwait.PollImmediate(APIReadyPollDuration, APIReadyPollTimeout, func() (bool, error) {
-		_, err := DoCNI(GetAPIEndpoint(MultusHealthAPIEndpoint), nil, SocketPath(socketPath))
+		_, err := DoCNI(GetAPIEndpoint(MultusReadyAPIEndpoint), nil, SocketPath(socketPath))
 		return err == nil, nil
 	})
 }

--- a/pkg/server/thick_cni_test.go
+++ b/pkg/server/thick_cni_test.go
@@ -274,7 +274,7 @@ func createFakePod(k8sClient *k8s.ClientInfo, podName string) error {
 func startCNIServer(ctx context.Context, runDir string, k8sClient *k8s.ClientInfo, servConfig []byte) (*Server, error) {
 	const period = 0
 
-	cniServer, err := newCNIServer(runDir, k8sClient, &fakeExec{}, servConfig, true)
+	cniServer, err := newCNIServer(runDir, k8sClient, &fakeExec{}, servConfig, true, func() bool { return false })
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR introduces graceful shutdown functionality to the Multus daemon by adding a `/readyz` endpoint alongside the existing `/healthz`. The /readyz endpoint starts returning 500 once a SIGTERM is received, indicating the daemon is in shutdown mode. During this time, CNI requests can still be processed for a short window. The daemonset configs have been updated to increase `terminationGracePeriodSeconds` from 10 to 30 seconds, ensuring we have a bit more time for these clean shutdowns.

This addresses a race condition during pod transitions where the readiness check might return true, but a subsequent CNI request could fail if the daemon shuts down too quickly. By introducing the /readyz endpoint and delaying the shutdown, we can handle ongoing CNI requests more gracefully, reducing the risk of disruptions during critical transitions.

Major thanks to @deads2k for the find, identification, fix, and of course, the explanations. Appreciate it.