### PR TITLE
[do not merge][test] Tests change to net-attach-def library

### DIFF
--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -770,6 +770,8 @@ func CmdAdd(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) (c
 		}
 	}
 
+	logging.Debugf("!bang the whole result ON ADD: %+v", result)
+
 	return result, nil
 }
 


### PR DESCRIPTION
…efault=true in status

This is a test change to the library for determination of the default=true interface in the network-status annotation when multiple interfaces are present in the result.

see also: https://github.com/openshift/ovn-kubernetes/pull/2320