### PR TITLE
OCPBUGS-43390: Update net-attach-def client library to 1.7.5 for cri-o functionality

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/containernetworking/plugins v1.1.0
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/go-logr/logr v1.3.0 // indirect
-	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.3
+	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.5
 	github.com/onsi/ginkgo/v2 v2.13.2
 	github.com/onsi/gomega v1.30.0
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -825,8 +825,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
-github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.3 h1:W44yEuOvwcBErGzSjjVGEbmHh8oRGLmxDSC2yVJQ2aM=
-github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.3/go.mod h1:CM7HAH5PNuIsqjMN0fGc1ydM74Uj+0VZFhob620nklw=
+github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.5 h1:CELpSMPSyicFBaVsxROmfrWlu9yr3Dduk+y7vGrIsx8=
+github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.5/go.mod h1:CM7HAH5PNuIsqjMN0fGc1ydM74Uj+0VZFhob620nklw=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/utils/net-attach-def.go
+++ b/vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/utils/net-attach-def.go
@@ -122,6 +122,16 @@ func GetNetworkStatus(pod *corev1.Pod) ([]v1.NetworkStatus, error) {
 	return netStatuses, err
 }
 
+// gatewayInterfaceIndex determines the index of the first interface that has a gateway
+func gatewayInterfaceIndex(ips []*cni100.IPConfig) int {
+	for _, ipConfig := range ips {
+		if ipConfig.Gateway != nil && ipConfig.Interface != nil {
+			return *ipConfig.Interface
+		}
+	}
+	return -1
+}
+
 // CreateNetworkStatuses creates an array of NetworkStatus from CNI result
 // Not to be confused with CreateNetworkStatus (singular)
 // This is the preferred method and picks up when CNI ADD results contain multiple container interfaces
@@ -147,14 +157,36 @@ func CreateNetworkStatuses(r cnitypes.Result, networkName string, defaultNetwork
 	// Same for DNS
 	v1dns := convertDNS(result.DNS)
 
+	// Check for a gateway-associated interface, we'll use this later if we did to mark as the default.
+	gwInterfaceIdx := -1
+	if defaultNetwork {
+		gwInterfaceIdx = gatewayInterfaceIndex(result.IPs)
+	}
+
 	// Initialize NetworkStatus for each container interface (e.g. with sandbox present)
 	indexOfFoundPodInterface := 0
 	foundFirstSandboxIface := false
+	didSetDefault := false
 	for i, iface := range result.Interfaces {
 		if iface.Sandbox != "" {
+			isDefault := false
+
+			// If there's a gateway listed for this interface index found in the ips, we mark that interface as default
+			// notably, we use the first one we find.
+			if defaultNetwork && i == gwInterfaceIdx && !didSetDefault {
+				isDefault = true
+				didSetDefault = true
+			}
+
+			// Otherwise, if we didn't find it, we use the first sandbox interface.
+			if defaultNetwork && gwInterfaceIdx == -1 && !foundFirstSandboxIface {
+				isDefault = true
+				foundFirstSandboxIface = true
+			}
+
 			ns := &v1.NetworkStatus{
 				Name:       networkName,
-				Default:    defaultNetwork && !foundFirstSandboxIface,
+				Default:    isDefault,
 				Interface:  iface.Name,
 				Mac:        iface.Mac,
 				Mtu:        iface.Mtu,
@@ -167,7 +199,6 @@ func CreateNetworkStatuses(r cnitypes.Result, networkName string, defaultNetwork
 			// Map original index to the new slice index
 			indexMap[i] = indexOfFoundPodInterface
 			indexOfFoundPodInterface++
-			foundFirstSandboxIface = true
 		}
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -114,7 +114,7 @@ github.com/josharian/intern
 # github.com/json-iterator/go v1.1.12
 ## explicit; go 1.12
 github.com/json-iterator/go
-# github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.3
+# github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.5
 ## explicit; go 1.21
 github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io
 github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1


### PR DESCRIPTION
From the release notes:

> This release contains a fix related to the determination of the default interface, e.g. setting the default parameter to true in the network-status annotation based on the presence of a gateway in the CNI ADD success result ips.gateway and makes the determination of the default based on the first interface that has an associated value of gateway (using the interface index in the ips element in the CNI ADD success result).

> This provides flexibility especially in CRI-O which uses the first interface and IP addresses for the pod.IP in Kubernetes, therefore. Containerd functionality is unchanged in that it uses the value for the IP addresses specifically

> It's worth noting that CNI ADD success results which do not contain any interfaces will be discarded in this determination of the default, therefore it's recommended to set one with an associated gateway if aiming to have it be noted as the default.

See also:
https://github.com/k8snetworkplumbingwg/network-attachment-definition-client/releases/tag/v1.7.5 https://github.com/k8snetworkplumbingwg/network-attachment-definition-client/pull/73