### PR TITLE
OCPBUGS-45037: Bring in getpodcontext (fix cache miss carry)

### DIFF
--- a/pkg/k8sclient/k8sclient.go
+++ b/pkg/k8sclient/k8sclient.go
@@ -92,8 +92,8 @@ func (c *ClientInfo) GetPodContext(ctx context.Context, namespace, name string) 
 }
 
 // GetPodAPILiveQuery does a live API query for the pod, instead of using informers, for cases when a failure occurred, as to prevent a cache miss.
-func (c *ClientInfo) GetPodAPILiveQuery(namespace, name string) (*v1.Pod, error) {
-	return c.Client.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+func (c *ClientInfo) GetPodAPILiveQuery(ctx context.Context, namespace, name string) (*v1.Pod, error) {
+	return c.Client.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
 }
 
 // DeletePod deletes a pod from kubernetes

--- a/pkg/k8sclient/k8sclient.go
+++ b/pkg/k8sclient/k8sclient.go
@@ -82,10 +82,6 @@ func (c *ClientInfo) GetPod(namespace, name string) (*v1.Pod, error) {
 	return c.Client.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
 
-func (c *ClientInfo) GetPodLive(namespace, name string) (*v1.Pod, error) {
-	return c.Client.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-}
-
 // DeletePod deletes a pod from kubernetes
 func (c *ClientInfo) DeletePod(namespace, name string) error {
 	return c.Client.CoreV1().Pods(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})

--- a/pkg/k8sclient/k8sclient.go
+++ b/pkg/k8sclient/k8sclient.go
@@ -91,6 +91,11 @@ func (c *ClientInfo) GetPodContext(ctx context.Context, namespace, name string) 
 	return c.Client.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
 }
 
+// GetPodAPILiveQuery does a live API query for the pod, instead of using informers, for cases when a failure occurred, as to prevent a cache miss.
+func (c *ClientInfo) GetPodAPILiveQuery(namespace, name string) (*v1.Pod, error) {
+	return c.Client.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
 // DeletePod deletes a pod from kubernetes
 func (c *ClientInfo) DeletePod(namespace, name string) error {
 	return c.Client.CoreV1().Pods(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})

--- a/pkg/k8sclient/k8sclient.go
+++ b/pkg/k8sclient/k8sclient.go
@@ -82,6 +82,15 @@ func (c *ClientInfo) GetPod(namespace, name string) (*v1.Pod, error) {
 	return c.Client.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
 
+// GetPodContext gets pod from kubernetes with context
+func (c *ClientInfo) GetPodContext(ctx context.Context, namespace, name string) (*v1.Pod, error) {
+	if c.PodInformer != nil {
+		logging.Debugf("GetPod for [%s/%s] will use informer cache", namespace, name)
+		return listers.NewPodLister(c.PodInformer.GetIndexer()).Pods(namespace).Get(name)
+	}
+	return c.Client.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+}
+
 // DeletePod deletes a pod from kubernetes
 func (c *ClientInfo) DeletePod(namespace, name string) error {
 	return c.Client.CoreV1().Pods(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})

--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -558,9 +558,7 @@ func GetPod(kubeClient *k8s.ClientInfo, k8sArgs *types.K8sArgs, isDel bool) (*v1
 		// Try one more time to get the pod directly from the apiserver;
 		// TODO: figure out why static pods don't show up via the informer
 		// and always hit this case.
-		ctx, cancel := context.WithTimeout(context.TODO(), pollDuration)
-		defer cancel()
-		pod, err = kubeClient.GetPodContext(ctx, podNamespace, podName)
+		pod, err = kubeClient.GetPodAPILiveQuery(podNamespace, podName)
 		if err != nil {
 			return nil, cmdErr(k8sArgs, "error waiting for pod: %v", err)
 		}

--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -555,7 +555,7 @@ func GetPod(kubeClient *k8s.ClientInfo, k8sArgs *types.K8sArgs, isDel bool) (*v1
 		// Try one more time to get the pod directly from the apiserver;
 		// TODO: figure out why static pods don't show up via the informer
 		// and always hit this case.
-		pod, err = kubeClient.GetPodLive(podNamespace, podName)
+		pod, err = kubeClient.GetPod(podNamespace, podName)
 		if err != nil {
 			return nil, cmdErr(k8sArgs, "error waiting for pod: %v", err)
 		}

--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -558,7 +558,9 @@ func GetPod(kubeClient *k8s.ClientInfo, k8sArgs *types.K8sArgs, isDel bool) (*v1
 		// Try one more time to get the pod directly from the apiserver;
 		// TODO: figure out why static pods don't show up via the informer
 		// and always hit this case.
-		pod, err = kubeClient.GetPodAPILiveQuery(podNamespace, podName)
+		ctx, cancel := context.WithTimeout(context.TODO(), pollDuration)
+		defer cancel()
+		pod, err = kubeClient.GetPodAPILiveQuery(ctx, podNamespace, podName)
 		if err != nil {
 			return nil, cmdErr(k8sArgs, "error waiting for pod: %v", err)
 		}


### PR DESCRIPTION
Reverts carry 713f28b51aeda2d3278c24062c5b7619bc1c8a63

Brings in changes from:

context for getpod: https://github.com/k8snetworkplumbingwg/multus-cni/pull/1372/commits

and getlivepod to avoid cache misses (to patch carry with upstream): https://github.com/k8snetworkplumbingwg/multus-cni/pull/1332/files