### PR TITLE
OCPBUGS-53087: Tolerate issues writing network status annotation on CNI ADD

### DIFF
--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -762,15 +762,17 @@ func CmdAdd(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) (c
 		}
 	}
 
-	// set the network status annotation in apiserver, only in case Multus as kubeconfig
+	// set the network status annotation in apiserver, only in case Multus has kubeconfig
 	if kubeClient != nil && kc != nil {
 		if !types.CheckSystemNamespaces(string(k8sArgs.K8S_POD_NAME), n.SystemNamespaces) {
 			err = k8s.SetNetworkStatus(kubeClient, k8sArgs, netStatus, n)
 			if err != nil {
-				if strings.Contains(err.Error(), "failed to query the pod") {
-					return nil, cmdErr(k8sArgs, "error setting the networks status, pod was already deleted: %v", err)
+				if strings.Contains(err.Error(), `pod "`) && strings.Contains(err.Error(), `" not found`) {
+					// Tolerate issues with writing the status due to pod deletion, and log them.
+					logging.Verbosef("warning: tolerated failure writing network status (pod not found): %v", err)
+				} else {
+					return nil, cmdErr(k8sArgs, "error setting the networks status: %v", err)
 				}
-				return nil, cmdErr(k8sArgs, "error setting the networks status: %v", err)
 			}
 		}
 	}


### PR DESCRIPTION
This change adds toleration for such errors like:

```
failed to [query/update] the pod pod-name-here in out of cluster comm: pod "pod-name-here" not found
```

During CNI ADD. ~While this change is a trade off in terms of debugability for RBAC, it's potentially noisy in scaled clusters when it is working properly.~

(edit: that's not the case anymore after I updated my code)