### PR TITLE
[release-4.21] OCPBUGS-82064: Bump CNI version to 1.1.0

### DIFF
--- a/cmd/thin_entrypoint/main.go
+++ b/cmd/thin_entrypoint/main.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/containernetworking/cni/libcni"
+	cniversion "github.com/containernetworking/cni/pkg/version"
 	"github.com/spf13/pflag"
 
 	"gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/cmdutils"
@@ -497,14 +498,14 @@ func (o *Options) createMultusConfig(prevMasterConfigFileHash []byte) (string, [
 		return "", nil, fmt.Errorf("cannot create multus cni temp file: %v", err)
 	}
 
-	// use conflist template if cniVersionConfig == "1.0.0"
+	// use conflist template if cniVersionConfig >= "1.0.0"
 	multusConfFilePath := fmt.Sprintf("%s/00-multus.conf", o.CNIConfDir)
 	templateMultusConfig, err := template.New("multusCNIConfig").Parse(multusConfTemplate)
 	if err != nil {
 		return "", nil, fmt.Errorf("template parse error: %v", err)
 	}
 
-	if o.CNIVersion == "1.0.0" { //Check 1.0.0 or above!
+	if gt, err := cniversion.GreaterThanOrEqualTo(o.CNIVersion, "1.0.0"); err == nil && gt {
 		multusConfFilePath = fmt.Sprintf("%s/00-multus.conflist", o.CNIConfDir)
 		templateMultusConfig, err = template.New("multusCNIConfig").Parse(multusConflistTemplate)
 		if err != nil {

--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -764,10 +764,10 @@ func CmdAdd(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) (c
 
 	pod, err := GetPod(kubeClient, k8sArgs, false)
 	if err != nil {
-		if err == errPodNotFound {
-			emptyresult := emptyCNIResult(args, "1.0.0")
-			logging.Verbosef("CmdAdd: Warning: pod [%s/%s] not found, exiting with empty CNI result: %v", k8sArgs.K8S_POD_NAMESPACE, k8sArgs.K8S_POD_NAME, emptyresult)
-			return emptyresult, nil
+		if stderrors.Is(err, errPodNotFound) {
+			emptyResult := emptyCNIResult(args, n.CNIVersion)
+			logging.Verbosef("CmdAdd: Warning: pod [%s/%s] not found, exiting with empty CNI result: %v", k8sArgs.K8S_POD_NAMESPACE, k8sArgs.K8S_POD_NAME, emptyResult)
+			return emptyResult, nil
 		}
 		return nil, err
 	}

--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -18,6 +18,7 @@ package multus
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"net"
 	"os"
@@ -30,6 +31,7 @@ import (
 	"github.com/containernetworking/cni/pkg/skel"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	cni100 "github.com/containernetworking/cni/pkg/types/100"
+	cniversion "github.com/containernetworking/cni/pkg/version"
 	"github.com/containernetworking/plugins/pkg/ns"
 	nettypes "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	nadutils "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/utils"
@@ -258,6 +260,42 @@ func confDel(rt *libcni.RuntimeConf, rawNetconf []byte, multusNetconf *types.Net
 	return err
 }
 
+func confStatus(rt *libcni.RuntimeConf, rawNetconf []byte, multusNetconf *types.NetConf, exec invoke.Exec) error {
+	logging.Debugf("confStatus: %v, %s", rt, string(rawNetconf))
+
+	binDirs := filepath.SplitList(os.Getenv("CNI_PATH"))
+	binDirs = append([]string{multusNetconf.BinDir}, binDirs...)
+	cniNet := libcni.NewCNIConfigWithCacheDir(binDirs, multusNetconf.CNIDir, exec)
+
+	conf, err := libcni.ConfFromBytes(rawNetconf)
+	if err != nil {
+		return logging.Errorf("error in converting the raw bytes to conf: %v", err)
+	}
+
+	if gt, _ := cniversion.GreaterThanOrEqualTo(conf.Network.CNIVersion, "1.1.0"); !gt {
+		logging.Debugf("confStatus: skipping STATUS for network %q type %q cniVersion %q (< 1.1.0)",
+			conf.Network.Name, conf.Network.Type, conf.Network.CNIVersion)
+		return nil
+	}
+
+	confList := &libcni.NetworkConfigList{
+		Name:       conf.Network.Name,
+		CNIVersion: conf.Network.CNIVersion,
+		Plugins:    []*libcni.PluginConfig{conf},
+	}
+
+	err = cniNet.GetStatusNetworkList(context.Background(), confList)
+	if err != nil {
+		var cniErr *cnitypes.Error
+		if stderrors.As(err, &cniErr) {
+			return err
+		}
+		return logging.Errorf("error in getting result from StatusNetworkList: %v", err)
+	}
+
+	return err
+}
+
 func conflistAdd(rt *libcni.RuntimeConf, rawnetconflist []byte, cniConfList *libcni.NetworkConfigList, multusNetconf *types.NetConf, exec invoke.Exec) (cnitypes.Result, error) {
 	logging.Debugf("conflistAdd: %v, %s", rt, string(rawnetconflist))
 	// In part, adapted from K8s pkg/kubelet/dockershim/network/cni/cni.go
@@ -322,6 +360,33 @@ func conflistDel(rt *libcni.RuntimeConf, rawnetconflist []byte, multusNetconf *t
 	err = cniNet.DelNetworkList(context.Background(), confList, rt)
 	if err != nil {
 		return logging.Errorf("conflistDel: error in getting result from DelNetworkList: %v", err)
+	}
+
+	return err
+}
+
+func conflistStatus(rt *libcni.RuntimeConf, rawnetconflist []byte, multusNetconf *types.NetConf, exec invoke.Exec) error {
+	logging.Debugf("conflistStatus: %v, %s", rt, string(rawnetconflist))
+
+	binDirs := filepath.SplitList(os.Getenv("CNI_PATH"))
+	binDirs = append([]string{multusNetconf.BinDir}, binDirs...)
+	cniNet := libcni.NewCNIConfigWithCacheDir(binDirs, multusNetconf.CNIDir, exec)
+
+	confList, err := libcni.ConfListFromBytes(rawnetconflist)
+	if err != nil {
+		return logging.Errorf("conflistStatus: error converting the raw bytes into a conflist: %v", err)
+	}
+	if gt, _ := cniversion.GreaterThanOrEqualTo(confList.CNIVersion, "1.1.0"); !gt {
+		logging.Debugf("conflistStatus: skipping STATUS for network list %q cniVersion %q (< 1.1.0)", confList.Name, confList.CNIVersion)
+	}
+
+	err = cniNet.GetStatusNetworkList(context.Background(), confList)
+	if err != nil {
+		var cniErr *cnitypes.Error
+		if stderrors.As(err, &cniErr) {
+			return err
+		}
+		return logging.Errorf("conflistStatus: error in getting result from StatusNetworkList: %v", err)
 	}
 
 	return err
@@ -451,6 +516,46 @@ func DelegateCheck(exec invoke.Exec, delegateConf *types.DelegateNetConf, rt *li
 		if err != nil {
 			return logging.Errorf("DelegateCheck: error invoking DelegateCheck - %q: %v", delegateConf.Conf.Type, err)
 		}
+	}
+
+	return err
+}
+
+// DelegateStatus ...
+func DelegateStatus(exec invoke.Exec, delegateConf *types.DelegateNetConf, rt *libcni.RuntimeConf, multusNetconf *types.NetConf) error {
+	logging.Debugf("DelegateStatus: %v, %v, %v", exec, delegateConf, rt)
+
+	isConfList := delegateConf.ConfListPlugin
+	if !isConfList && delegateConf.Conf.Type == "" && delegateConf.ConfList.Name != "" {
+		isConfList = true
+	}
+
+	if logging.GetLoggingLevel() >= logging.VerboseLevel {
+		var cniConfName string
+		if isConfList {
+			cniConfName = delegateConf.ConfList.Name
+		} else {
+			cniConfName = delegateConf.Conf.Name
+		}
+		logging.Verbosef("Status: %s:%s:%s(%s):%s %s", rt.Args[1][1], rt.Args[2][1], delegateConf.Name, cniConfName, rt.IfName, string(delegateConf.Bytes))
+	}
+
+	var err error
+	if isConfList {
+		err = conflistStatus(rt, delegateConf.Bytes, multusNetconf, exec)
+	} else {
+		err = confStatus(rt, delegateConf.Bytes, multusNetconf, exec)
+	}
+
+	if err != nil {
+		var cniErr *cnitypes.Error
+		if stderrors.As(err, &cniErr) {
+			return err
+		}
+		if isConfList {
+			return logging.Errorf("DelegateStatus: error invoking ConflistStatus - %q: %v", delegateConf.ConfList.Name, err)
+		}
+		return logging.Errorf("DelegateStatus: error invoking ConfStatus - %q: %v", delegateConf.Conf.Type, err)
 	}
 
 	return err
@@ -1050,17 +1155,26 @@ func CmdStatus(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo)
 
 	// invoke delegate's STATUS command
 	// we only need to check cluster network status
+	delegate := n.Delegates[0]
+	if !delegate.ConfListPlugin {
+		return confStatus(&libcni.RuntimeConf{}, delegate.Bytes, n, exec)
+	}
+
 	binDirs := filepath.SplitList(os.Getenv("CNI_PATH"))
 	binDirs = append([]string{n.BinDir}, binDirs...)
 	cniNet := libcni.NewCNIConfigWithCacheDir(binDirs, n.CNIDir, exec)
 
-	conf, err := libcni.ConfListFromBytes(n.Delegates[0].Bytes)
+	conf, err := libcni.ConfListFromBytes(delegate.Bytes)
 	if err != nil {
 		return logging.Errorf("error in converting the raw bytes to conf: %v", err)
 	}
 
-	err = cniNet.GetStatusNetworkList(context.TODO(), conf)
+	err = cniNet.GetStatusNetworkList(context.Background(), conf)
 	if err != nil {
+		var cniErr *cnitypes.Error
+		if stderrors.As(err, &cniErr) {
+			return err
+		}
 		return logging.Errorf("error in STATUS command: %v", err)
 	}
 

--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -378,6 +378,7 @@ func conflistStatus(rt *libcni.RuntimeConf, rawnetconflist []byte, multusNetconf
 	}
 	if gt, _ := cniversion.GreaterThanOrEqualTo(confList.CNIVersion, "1.1.0"); !gt {
 		logging.Debugf("conflistStatus: skipping STATUS for network list %q cniVersion %q (< 1.1.0)", confList.Name, confList.CNIVersion)
+		return nil
 	}
 
 	err = cniNet.GetStatusNetworkList(context.Background(), confList)

--- a/pkg/netutils/netutils.go
+++ b/pkg/netutils/netutils.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 
 	"github.com/containernetworking/cni/libcni"
+	cniversion "github.com/containernetworking/cni/pkg/version"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
@@ -183,7 +184,7 @@ func deleteDefaultGWResult(result map[string]interface{}, ipv4, ipv6 bool) (map[
 		return deleteDefaultGWResult020(result, ipv4, ipv6)
 	}
 
-	if cniVersion != "0.3.0" && cniVersion != "0.3.1" && cniVersion != "0.4.0" && cniVersion != "1.0.0" {
+	if !isSupportedGatewayResultVersion(cniVersion) {
 		return nil, fmt.Errorf("not supported version: %s", cniVersion)
 	}
 
@@ -340,7 +341,7 @@ func addDefaultGWResult(result map[string]interface{}, gw []net.IP) (map[string]
 		return addDefaultGWResult020(result, gw)
 	}
 
-	if cniVersion != "0.3.0" && cniVersion != "0.3.1" && cniVersion != "0.4.0" && cniVersion != "1.0.0" {
+	if !isSupportedGatewayResultVersion(cniVersion) {
 		return nil, fmt.Errorf("not supported version: %s", cniVersion)
 	}
 
@@ -366,6 +367,19 @@ func addDefaultGWResult(result map[string]interface{}, gw []net.IP) (map[string]
 	result["routes"] = routes
 
 	return result, nil
+}
+
+func isSupportedGatewayResultVersion(cniVersion string) bool {
+	switch cniVersion {
+	case "0.3.0", "0.3.1", "0.4.0":
+		return true
+	}
+
+	if gt, _ := cniversion.GreaterThanOrEqualTo(cniVersion, "1.0.0"); gt {
+		return true
+	}
+
+	return false
 }
 
 func addDefaultGWResult020(result map[string]interface{}, gw []net.IP) (map[string]interface{}, error) {

--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"time"
 
+	cnitypes "github.com/containernetworking/cni/pkg/types"
+
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -74,6 +76,10 @@ func DoCNI(url string, req interface{}, socketPath string) ([]byte, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		cniErr := &cnitypes.Error{}
+		if err := json.Unmarshal(body, cniErr); err == nil && cniErr.Msg != "" {
+			return nil, cniErr
+		}
 		return nil, fmt.Errorf("CNI request failed with status %v: '%s'", resp.StatusCode, string(body))
 	}
 

--- a/pkg/server/api/shim.go
+++ b/pkg/server/api/shim.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"os"
 	"strings"
@@ -111,6 +112,10 @@ func postRequest(args *skel.CmdArgs, readinessCheck readyCheckFunc) (*Response, 
 	var body []byte
 	body, err = DoCNI("http://dummy/cni", cniRequest, SocketPath(multusShimConfig.MultusSocketDir))
 	if err != nil {
+		var cniErr *cnitypes.Error
+		if stderrors.As(err, &cniErr) {
+			return nil, multusShimConfig.CNIVersion, err
+		}
 		return nil, multusShimConfig.CNIVersion, fmt.Errorf("%s: StdinData: %s", err.Error(), string(args.StdinData))
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -84,6 +84,7 @@ func printCmdArgs(args *skel.CmdArgs) string {
 
 // HandleCNIRequest is the CNI server handler function; it is invoked whenever
 // a CNI request is processed.
+// Note: k8sArgs may be nil for plugin-level commands (STATUS, GC) that have no pod context.
 func (s *Server) HandleCNIRequest(cmd string, k8sArgs *types.K8sArgs, cniCmdArgs *skel.CmdArgs) ([]byte, error) {
 	var result []byte
 	var err error
@@ -681,12 +682,12 @@ func (s *Server) cmdCheck(cmdArgs *skel.CmdArgs, k8sArgs *types.K8sArgs) error {
 	return multus.CmdCheck(cmdArgs, s.exec, s.kubeclient)
 }
 
-func (s *Server) cmdGC(cmdArgs *skel.CmdArgs, k8sArgs *types.K8sArgs) error {
+func (s *Server) cmdGC(cmdArgs *skel.CmdArgs, _ *types.K8sArgs) error {
 	logging.Debugf("CmdGC. CNI conf: %+v", *cmdArgs)
 	return multus.CmdGC(cmdArgs, s.exec, s.kubeclient)
 }
 
-func (s *Server) cmdStatus(cmdArgs *skel.CmdArgs, k8sArgs *types.K8sArgs) error {
+func (s *Server) cmdStatus(cmdArgs *skel.CmdArgs, _ *types.K8sArgs) error {
 	logging.Debugf("CmdStatus. CNI conf: %+v", *cmdArgs)
 	return multus.CmdStatus(cmdArgs, s.exec, s.kubeclient)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -17,6 +17,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -125,6 +126,8 @@ func (s *Server) HandleDelegateRequest(cmd string, k8sArgs *types.K8sArgs, cniCm
 		err = s.cmdDelegateDel(cniCmdArgs, k8sArgs, multusConfig)
 	case "CHECK":
 		err = s.cmdDelegateCheck(cniCmdArgs, k8sArgs, multusConfig)
+	case "STATUS":
+		err = s.cmdDelegateStatus(cniCmdArgs, k8sArgs, multusConfig)
 	default:
 		return []byte(""), fmt.Errorf("unknown cmd type: %s", cmd)
 	}
@@ -302,7 +305,7 @@ func newCNIServer(rundir string, kubeClient *k8s.ClientInfo, exec invoke.Exec, s
 
 			result, err := s.handleCNIRequest(r)
 			if err != nil {
-				http.Error(w, fmt.Sprintf("%v", err), http.StatusBadRequest)
+				s.writeCNIErrorResponse(w, err)
 				return
 			}
 
@@ -324,7 +327,7 @@ func newCNIServer(rundir string, kubeClient *k8s.ClientInfo, exec invoke.Exec, s
 
 			result, err := s.handleDelegateRequest(r)
 			if err != nil {
-				http.Error(w, fmt.Sprintf("%v", err), http.StatusBadRequest)
+				s.writeCNIErrorResponse(w, err)
 				return
 			}
 
@@ -406,6 +409,34 @@ func (s *Server) Start(ctx context.Context, l net.Listener) {
 	}()
 }
 
+func (s *Server) writeCNIErrorResponse(w http.ResponseWriter, err error) {
+	var cniErr *cnitypes.Error
+	if errors.As(err, &cniErr) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		errBytes, marshalErr := json.Marshal(cniErr)
+		if marshalErr != nil {
+			http.Error(w, fmt.Sprintf("%v", err), http.StatusBadRequest)
+			return
+		}
+		if _, writeErr := w.Write(errBytes); writeErr != nil {
+			_ = logging.Errorf("Error writing HTTP response: %v", writeErr)
+		}
+		return
+	}
+	http.Error(w, fmt.Sprintf("%v", err), http.StatusBadRequest)
+}
+
+func (s *Server) wrapCNIRequestError(cmdArgs *skel.CmdArgs, err error) error {
+	var cniErr *cnitypes.Error
+	if errors.As(err, &cniErr) {
+		_ = logging.Errorf("%s ERRORED: %v", printCmdArgs(cmdArgs), err)
+		return err
+	}
+	// Prefix error with request information for easier debugging.
+	return fmt.Errorf("%s ERRORED: %v", printCmdArgs(cmdArgs), err)
+}
+
 func (s *Server) handleCNIRequest(r *http.Request) ([]byte, error) {
 	var cr api.Request
 	b, err := io.ReadAll(r.Body)
@@ -427,8 +458,7 @@ func (s *Server) handleCNIRequest(r *http.Request) ([]byte, error) {
 
 	result, err := s.HandleCNIRequest(cmdType, k8sArgs, cniCmdArgs)
 	if err != nil {
-		// Prefix error with request information for easier debugging
-		return nil, fmt.Errorf("%s ERRORED: %v", printCmdArgs(cniCmdArgs), err)
+		return nil, s.wrapCNIRequestError(cniCmdArgs, err)
 	}
 	return result, nil
 }
@@ -454,8 +484,7 @@ func (s *Server) handleDelegateRequest(r *http.Request) ([]byte, error) {
 
 	result, err := s.HandleDelegateRequest(cmdType, k8sArgs, cniCmdArgs, cr.InterfaceAttributes)
 	if err != nil {
-		// Prefix error with request information for easier debugging
-		return nil, fmt.Errorf("%s ERRORED: %v", printCmdArgs(cniCmdArgs), err)
+		return nil, s.wrapCNIRequestError(cniCmdArgs, err)
 	}
 	return result, nil
 }
@@ -720,6 +749,15 @@ func (s *Server) cmdDelegateCheck(cmdArgs *skel.CmdArgs, k8sArgs *types.K8sArgs,
 	delegateCNIConf.Bytes = cmdArgs.StdinData
 	rt, _ := types.CreateCNIRuntimeConf(cmdArgs, k8sArgs, cmdArgs.IfName, nil, delegateCNIConf)
 	return multus.DelegateCheck(s.exec, delegateCNIConf, rt, multusConfig)
+}
+
+func (s *Server) cmdDelegateStatus(cmdArgs *skel.CmdArgs, k8sArgs *types.K8sArgs, multusConfig *types.NetConf) error {
+	delegateCNIConf, err := types.LoadDelegateNetConf(cmdArgs.StdinData, nil, "", "")
+	if err != nil {
+		return err
+	}
+	rt, _ := types.CreateCNIRuntimeConf(cmdArgs, k8sArgs, cmdArgs.IfName, nil, delegateCNIConf)
+	return multus.DelegateStatus(s.exec, delegateCNIConf, rt, multusConfig)
 }
 
 // note: this function may send back error to the client. In cni spec, command DEL should NOT send any error

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -451,9 +451,14 @@ func (s *Server) handleCNIRequest(r *http.Request) ([]byte, error) {
 		return nil, fmt.Errorf("could not extract the CNI command args: %w", err)
 	}
 
-	k8sArgs, err := kubernetesRuntimeArgs(cr.Env, s.kubeclient)
-	if err != nil {
-		return nil, fmt.Errorf("could not extract the kubernetes runtime args: %w", err)
+	// STATUS and GC are plugin-level commands with no pod context,
+	// so they don't have K8S_POD_NAME/K8S_POD_NAMESPACE in CNI_ARGS.
+	var k8sArgs *types.K8sArgs
+	if cmdType != "STATUS" && cmdType != "GC" {
+		k8sArgs, err = kubernetesRuntimeArgs(cr.Env, s.kubeclient)
+		if err != nil {
+			return nil, fmt.Errorf("could not extract the kubernetes runtime args: %w", err)
+		}
 	}
 
 	result, err := s.HandleCNIRequest(cmdType, k8sArgs, cniCmdArgs)
@@ -531,6 +536,18 @@ func (s *Server) extractCniData(cniRequest *api.Request, overrideConf []byte) (s
 	}
 
 	cniCmdArgs := &skel.CmdArgs{}
+
+	// STATUS and GC are plugin-level commands with no pod context;
+	// they don't require CNI_CONTAINERID, CNI_NETNS, or CNI_ARGS.
+	if cmd == "STATUS" || cmd == "GC" {
+		var err error
+		cniCmdArgs.StdinData, err = overrideCNIConfigWithServerConfig(cniRequest.Config, overrideConf, s.ignoreReadinessIndicator)
+		if err != nil {
+			return "", nil, err
+		}
+		return cmd, cniCmdArgs, nil
+	}
+
 	cniCmdArgs.ContainerID, ok = cniRequest.Env["CNI_CONTAINERID"]
 	if !ok {
 		return "", nil, fmt.Errorf("missing CNI_CONTAINERID")
@@ -665,24 +682,12 @@ func (s *Server) cmdCheck(cmdArgs *skel.CmdArgs, k8sArgs *types.K8sArgs) error {
 }
 
 func (s *Server) cmdGC(cmdArgs *skel.CmdArgs, k8sArgs *types.K8sArgs) error {
-	namespace := string(k8sArgs.K8S_POD_NAMESPACE)
-	podName := string(k8sArgs.K8S_POD_NAME)
-	if namespace == "" || podName == "" {
-		return fmt.Errorf("required CNI variable missing. pod name: %s; pod namespace: %s", podName, namespace)
-	}
-
-	logging.Debugf("CmdGC for [%s/%s]. CNI conf: %+v", namespace, podName, *cmdArgs)
+	logging.Debugf("CmdGC. CNI conf: %+v", *cmdArgs)
 	return multus.CmdGC(cmdArgs, s.exec, s.kubeclient)
 }
 
 func (s *Server) cmdStatus(cmdArgs *skel.CmdArgs, k8sArgs *types.K8sArgs) error {
-	namespace := string(k8sArgs.K8S_POD_NAMESPACE)
-	podName := string(k8sArgs.K8S_POD_NAME)
-	if namespace == "" || podName == "" {
-		return fmt.Errorf("required CNI variable missing. pod name: %s; pod namespace: %s", podName, namespace)
-	}
-
-	logging.Debugf("CmdStatus for [%s/%s]. CNI conf: %+v", namespace, podName, *cmdArgs)
+	logging.Debugf("CmdStatus. CNI conf: %+v", *cmdArgs)
 	return multus.CmdStatus(cmdArgs, s.exec, s.kubeclient)
 }
 

--- a/pkg/server/thick_cni_test.go
+++ b/pkg/server/thick_cni_test.go
@@ -105,7 +105,8 @@ var _ = Describe(suiteName, func() {
 			var err error
 			K8sClient = fakeK8sClient()
 			// Touch the default network file.
-			os.OpenFile(configPath, os.O_RDONLY|os.O_CREATE, 0755)
+			_, err = os.OpenFile(configPath, os.O_RDONLY|os.O_CREATE, 0755)
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(FilesystemPreRequirements(thickPluginRunDir)).To(Succeed())
 

--- a/pkg/server/thick_cni_test.go
+++ b/pkg/server/thick_cni_test.go
@@ -91,6 +91,69 @@ var _ = Describe(suiteName, func() {
 		})
 	})
 
+	Context("STATUS and GC commands without pod context", func() {
+		const configPath = "/tmp/foo.multus.conf"
+
+		var (
+			cniServer *Server
+			K8sClient *k8s.ClientInfo
+			ctx       context.Context
+			cancel    context.CancelFunc
+		)
+
+		BeforeEach(func() {
+			var err error
+			K8sClient = fakeK8sClient()
+			// Touch the default network file.
+			os.OpenFile(configPath, os.O_RDONLY|os.O_CREATE, 0755)
+
+			Expect(FilesystemPreRequirements(thickPluginRunDir)).To(Succeed())
+
+			ctx, cancel = context.WithCancel(context.TODO())
+			cniServer, err = startCNIServer(ctx, thickPluginRunDir, K8sClient, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Only set CNI_COMMAND — no CNI_CONTAINERID, CNI_NETNS, or CNI_ARGS
+			// to simulate how kubelet invokes STATUS/GC (plugin-level, no pod context).
+			os.Unsetenv("CNI_CONTAINERID")
+			os.Unsetenv("CNI_NETNS")
+			os.Unsetenv("CNI_ARGS")
+		})
+
+		AfterEach(func() {
+			cancel()
+			if _, errStat := os.Stat(configPath); errStat == nil {
+				Expect(os.Remove(configPath)).To(Succeed())
+			}
+			unregisterMetrics(cniServer)
+			Expect(cniServer.Close()).To(Succeed())
+			os.Unsetenv("CNI_COMMAND")
+			os.Unsetenv("CNI_ARGS")
+		})
+
+		It("STATUS succeeds with CNI_ARGS unset", func() {
+			Expect(os.Setenv("CNI_COMMAND", "STATUS")).NotTo(HaveOccurred())
+			Expect(api.CmdStatus(cniCmdArgs("", "", "", referenceConfig(thickPluginRunDir)))).To(Succeed())
+		})
+
+		It("GC succeeds with CNI_ARGS unset", func() {
+			Expect(os.Setenv("CNI_COMMAND", "GC")).NotTo(HaveOccurred())
+			Expect(api.CmdGC(cniCmdArgs("", "", "", referenceConfig(thickPluginRunDir)))).To(Succeed())
+		})
+
+		It("STATUS succeeds with CNI_ARGS empty", func() {
+			Expect(os.Setenv("CNI_COMMAND", "STATUS")).NotTo(HaveOccurred())
+			Expect(os.Setenv("CNI_ARGS", "")).NotTo(HaveOccurred())
+			Expect(api.CmdStatus(cniCmdArgs("", "", "", referenceConfig(thickPluginRunDir)))).To(Succeed())
+		})
+
+		It("GC succeeds with CNI_ARGS empty", func() {
+			Expect(os.Setenv("CNI_COMMAND", "GC")).NotTo(HaveOccurred())
+			Expect(os.Setenv("CNI_ARGS", "")).NotTo(HaveOccurred())
+			Expect(api.CmdGC(cniCmdArgs("", "", "", referenceConfig(thickPluginRunDir)))).To(Succeed())
+		})
+	})
+
 	Context("CNI operations started from the shim", func() {
 		const (
 			containerID = "123456789"


### PR DESCRIPTION
Manual cherry-pick of ea389005a1841b5964a2bdd28ab4df74ad8d9a09 e091897b4c0549e88e5d7370c38a146e5c154b08 921191dece729c8f25f6aaad51f7f31b29677a4a 56d18efde0df4833a48b3fa3f6387d2d00c8605b c943f9ffa2d6e79a2193864a0218220306bb8858 dfb8eaa 2a1b966. No conflicts.