### PR TITLE
OCPBUGS-83863: Simplify Dockerfile to rhel9-only build

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -21,27 +21,14 @@ RUN ./hack/build-go.sh && \
        cd /usr/src/multus-cni/bin
 WORKDIR /
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.25-openshift-4.22 AS rhel8
-ADD . /usr/src/multus-cni
-WORKDIR /usr/src/multus-cni
-ENV CGO_ENABLED=1
-ENV GO111MODULE=off
-ENV VERSION=rhel8 COMMIT=unset
-RUN ./hack/build-go.sh && \
-       cd /usr/src/multus-cni/bin
-WORKDIR /
-
 FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
 RUN dnf install -y util-linux && dnf clean all && \
        mkdir -p /usr/src/multus-cni/images && \
        mkdir -p /usr/src/multus-cni/bin && \
        mkdir -p /usr/src/multus-cni/rhel10/bin && \
-       mkdir -p /usr/src/multus-cni/rhel9/bin && \
-       mkdir -p /usr/src/multus-cni/rhel8/bin
+       mkdir -p /usr/src/multus-cni/rhel9/bin
 COPY --from=rhel10 /usr/src/multus-cni/bin /usr/src/multus-cni/rhel10/bin
 COPY --from=rhel9 /usr/src/multus-cni/bin /usr/src/multus-cni/rhel9/bin
-COPY --from=rhel8 /usr/src/multus-cni/bin /usr/src/multus-cni/rhel8/bin
-# copy container base image binary to /usr/src/multus-cni/bin
 RUN bash -c '. /etc/os-release; \
 	cp /usr/src/multus-cni/rhel$(echo "${VERSION_ID}" | cut -f 1 -d .)/bin/* /usr/src/multus-cni/bin'
 ADD ./images/entrypoint.sh /

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,16 +1,4 @@
 # This dockerfile is specific to building Multus for OpenShift
-# rhel10 golang builders don't exist yet, so use rhel9 for now
-# replace with rhel10 golang builder when it is released
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS rhel10
-ADD . /usr/src/multus-cni
-WORKDIR /usr/src/multus-cni
-ENV CGO_ENABLED=1
-ENV GO111MODULE=off
-ENV VERSION=rhel10 COMMIT=unset
-RUN ./hack/build-go.sh && \
-       cd /usr/src/multus-cni/bin
-WORKDIR /
-
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS rhel9
 ADD . /usr/src/multus-cni
 WORKDIR /usr/src/multus-cni
@@ -21,29 +9,11 @@ RUN ./hack/build-go.sh && \
        cd /usr/src/multus-cni/bin
 WORKDIR /
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.25-openshift-4.22 AS rhel8
-ADD . /usr/src/multus-cni
-WORKDIR /usr/src/multus-cni
-ENV CGO_ENABLED=1
-ENV GO111MODULE=off
-ENV VERSION=rhel8 COMMIT=unset
-RUN ./hack/build-go.sh && \
-       cd /usr/src/multus-cni/bin
-WORKDIR /
-
 FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
 RUN dnf install -y util-linux && dnf clean all && \
        mkdir -p /usr/src/multus-cni/images && \
-       mkdir -p /usr/src/multus-cni/bin && \
-       mkdir -p /usr/src/multus-cni/rhel10/bin && \
-       mkdir -p /usr/src/multus-cni/rhel9/bin && \
-       mkdir -p /usr/src/multus-cni/rhel8/bin
-COPY --from=rhel10 /usr/src/multus-cni/bin /usr/src/multus-cni/rhel10/bin
-COPY --from=rhel9 /usr/src/multus-cni/bin /usr/src/multus-cni/rhel9/bin
-COPY --from=rhel8 /usr/src/multus-cni/bin /usr/src/multus-cni/rhel8/bin
-# copy container base image binary to /usr/src/multus-cni/bin
-RUN bash -c '. /etc/os-release; \
-	cp /usr/src/multus-cni/rhel$(echo "${VERSION_ID}" | cut -f 1 -d .)/bin/* /usr/src/multus-cni/bin'
+       mkdir -p /usr/src/multus-cni/bin
+COPY --from=rhel9 /usr/src/multus-cni/bin /usr/src/multus-cni/bin
 ADD ./images/entrypoint.sh /
 
 LABEL io.k8s.display-name="Multus CNI" \

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -52,7 +52,8 @@ fi
 # Add version/commit/date into binary
 DATE=$(date -u -d "@${SOURCE_DATE_EPOCH:-$(date +%s)}" --iso-8601=seconds)
 COMMIT=${COMMIT:-$(git rev-parse --verify HEAD)}
-LDFLAGS="-X gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/multus.version=${VERSION} \
+LDFLAGS="-s -w \
+	-X gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/multus.version=${VERSION} \
 	-X gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/multus.commit=${COMMIT} \
 	-X gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/multus.gitTreeState=${GIT_TREE_STATE} \
 	-X gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/multus.releaseStatus=${RELEASE_STATUS} \


### PR DESCRIPTION
Remove the rhel8 and rhel10 build stages, strip debug symbols from binaries.

The rhel9/rhel10 version-specific subdirectories are no longer needed
since openshift/cluster-network-operator#2967 removed the OS detection
logic and now copies binaries directly from the base directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified OpenShift image build: consolidated per-release binaries into a single RHEL 9-based output, removed per-version packaging, and now deploys a unified binary layout for runtime.
  * Adjusted Go build to produce stripped binaries (debug symbols removed) to reduce artifact size while retaining version and build metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->