### PR TITLE
OCPBUGS-85253: Fix server url in kubeconfig

### DIFF
--- a/cmd/thin_entrypoint/main.go
+++ b/cmd/thin_entrypoint/main.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -199,7 +200,7 @@ func (o *Options) createKubeConfig(currentFileHash []byte) ([]byte, error) {
 		return nil, fmt.Errorf("template parse error: %v", err)
 	}
 	templateData := map[string]string{
-		"KubeConfigHost":          fmt.Sprintf("%s://[%s]:%s", kubeProtocol, kubeHost, kubePort),
+		"KubeConfigHost":          fmt.Sprintf("%s://%s", kubeProtocol, net.JoinHostPort(kubeHost, kubePort)),
 		"KubeServerTLS":           tlsConfig,
 		"KubeServiceAccountToken": string(saTokenByte),
 	}


### PR DESCRIPTION
Picks #273 

## Summary
- Replace `fmt.Sprintf("%s://[%s]:%s", ...)` with `net.JoinHostPort()` in `cmd/thin_entrypoint/main.go` to properly handle IPv6 addresses when constructing the Kubernetes service URL for the multus kubeconfig
- The previous code unconditionally wrapped `KUBERNETES_SERVICE_HOST` in brackets, which Go 1.24.8+ rejects for non-IPv6 addresses (CVE-2025-47912)
- `net.JoinHostPort()` correctly adds brackets only for IPv6 addresses

## Root cause
The thin entrypoint generates a kubeconfig for the multus CNI plugin. The server URL was constructed as `https://[host]:port` regardless of whether the host was an IPv6 address or a DNS hostname. With Go 1.24.8+, `url.Parse()` rejects brackets around non-IPv6 addresses, causing:

```
Multus: error getting k8s client: host must be a URL or a host:port pair: "https://[api-int.hostname]:6443"
```

This manifested as `FailedKillPod` errors when CRI-O invoked the multus CNI plugin to clean up pod networks.

## Test plan
- [ ] Verify build passes: `go build ./cmd/thin_entrypoint/`
- [ ] Verify tests pass: `go test ./cmd/thin_entrypoint/`
- [ ] Confirm kubeconfig generated by the thin entrypoint uses correct URL format for both IPv4/hostname and IPv6 API server addresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)