### PR TITLE
NO-ISSUE: [release-4.19] fix CI build root image

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: golang-1.10
+  tag: rhel-9-release-golang-1.22-openshift-4.19


### PR DESCRIPTION
## Summary
- Update `.ci-operator.yaml` build root from obsolete `golang-1.10` to `rhel-9-release-golang-1.22-openshift-4.19`