### PR TITLE
NO-ISSUE: [release-4.17] Bump Go to 1.22 and fix CI build root image

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: golang-1.10
+  tag: rhel-9-release-golang-1.22-openshift-4.17


### PR DESCRIPTION
## Summary
- Update `.ci-operator.yaml` build root from obsolete `golang-1.10` to `rhel-9-release-golang-1.22-openshift-4.17`
- Bump `go.mod` from `go 1.21` to `go 1.22` to match the build root image

The `verify-deps` CI job was failing because the `golang-1.10` build root image ships Go 1.10.8, which doesn't support `go mod` at all.

## Test plan
- [ ] `verify-deps` CI job passes
- [ ] Other CI jobs unaffected