### PR TITLE
NO-ISSUE: [release-4.18] Bump Go to 1.22 and fix CI build root image

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: golang-1.10
+  tag: rhel-9-release-golang-1.22-openshift-4.18


### PR DESCRIPTION
## Summary

- Update `.ci-operator.yaml` build root from `golang-1.10` to `rhel-9-release-golang-1.22-openshift-4.18`
- Bump `go.mod` Go version from 1.21 to 1.22 to match the build root image

The `verify-deps` CI job was failing because the `golang-1.10` build root image does not support Go modules.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>