### PR TITLE
NO-ISSUE: [release-4.16] Bump Go to 1.21 and fix CI build root image

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: golang-1.10
+  tag: rhel-9-release-golang-1.21-openshift-4.16


### PR DESCRIPTION
## Summary

- Update `.ci-operator.yaml` build root from `golang-1.10` to `rhel-9-release-golang-1.21-openshift-4.16`
- The `verify-deps` CI job was failing because `golang-1.10` does not support go modules

## Details

The `.ci-operator.yaml` was using the obsolete `golang-1.10` build root image (Go 1.10.8), which has no `go mod` support. This caused the `verify-deps` CI job to fail. The `go.mod` already specifies Go 1.21, so the build root image is updated to `rhel-9-release-golang-1.21-openshift-4.16` to match.

/cc @s1061123