### PR TITLE
no-issue: [release-4.15] Bump Go to 1.20 and fix CI build root image

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: golang-1.10
+  tag: rhel-9-release-golang-1.20-openshift-4.15


### PR DESCRIPTION
## Summary

- Update `.ci-operator.yaml` build root from `golang-1.10` to `rhel-9-release-golang-1.20-openshift-4.15`
- The `verify-deps` CI job was failing because `golang-1.10` does not support go modules
- `go.mod` already had `go 1.20`, so no go.mod change was needed

## Test plan

- [ ] `verify-deps` CI job passes with the new build root image
- [ ] Other CI jobs remain unaffected

Generated with [Claude Code](https://claude.ai/code)