### PR TITLE
OCPBUGS-85381: Sanitize bracketed hostnames in kubeconfig server URLs

### DIFF
--- a/pkg/k8sclient/kubeconfig.go
+++ b/pkg/k8sclient/kubeconfig.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"regexp"
 	"time"
 
 	certificatesv1 "k8s.io/api/certificates/v1"
@@ -149,6 +150,13 @@ func InClusterK8sClient() (*ClientInfo, error) {
 	return clientInfo, err
 }
 
+// sanitizeBracketedHost strips brackets from non-IPv6 hostnames that Go 1.24.8+ rejects (CVE-2025-47912).
+var bracketRegex = regexp.MustCompile(`(://)\[([^:]+)\]`)
+
+func sanitizeBracketedHost(serverURL string) string {
+	return bracketRegex.ReplaceAllString(serverURL, "$1$2")
+}
+
 // GetK8sClient gets client info from kubeconfig
 func GetK8sClient(kubeconfig string, kubeClient *ClientInfo) (*ClientInfo, error) {
 	logging.Debugf("GetK8sClient: %s, %v", kubeconfig, kubeClient)
@@ -168,6 +176,7 @@ func GetK8sClient(kubeconfig string, kubeClient *ClientInfo) (*ClientInfo, error
 		if err != nil {
 			return nil, logging.Errorf("GetK8sClient: failed to get context for the kubeconfig %v: %v", kubeconfig, err)
 		}
+		config.Host = sanitizeBracketedHost(config.Host)
 	} else if os.Getenv("KUBERNETES_SERVICE_HOST") != "" && os.Getenv("KUBERNETES_SERVICE_PORT") != "" {
 		// Try in-cluster config where multus might be running in a kubernetes pod
 		config, err = rest.InClusterConfig()

--- a/pkg/k8sclient/kubeconfig_test.go
+++ b/pkg/k8sclient/kubeconfig_test.go
@@ -1,0 +1,58 @@
+package k8sclient
+
+import (
+	"testing"
+)
+
+func TestSanitizeBracketedHost(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "hostname in brackets",
+			input:    "https://[api-int.ci-op-xxx.example.com]:6443",
+			expected: "https://api-int.ci-op-xxx.example.com:6443",
+		},
+		{
+			name:     "IPv4 in brackets",
+			input:    "https://[10.0.0.1]:6443",
+			expected: "https://10.0.0.1:6443",
+		},
+		{
+			name:     "IPv6 preserved",
+			input:    "https://[2001:db8::1]:6443",
+			expected: "https://[2001:db8::1]:6443",
+		},
+		{
+			name:     "IPv6 with hex ending preserved",
+			input:    "https://[2001:db8::face]:6443",
+			expected: "https://[2001:db8::face]:6443",
+		},
+		{
+			name:     "IPv6 loopback preserved",
+			input:    "https://[::1]:6443",
+			expected: "https://[::1]:6443",
+		},
+		{
+			name:     "no brackets unchanged",
+			input:    "https://api-server.example.com:6443",
+			expected: "https://api-server.example.com:6443",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeBracketedHost(tt.input)
+			if result != tt.expected {
+				t.Errorf("sanitizeBracketedHost(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Sanitize server URLs read from kubeconfig files in `GetK8sClient()` to strip brackets from non-IPv6 hostnames
- Fixes the 4.13-to-4.14 upgrade failure caused by Go 1.24.8+ (CVE-2025-47912) rejecting `https://[hostname]:6443`
- IPv6 addresses in brackets are correctly preserved (detected by the presence of colons)

## Root cause
During 4.13-to-4.14 upgrades, there is a race window between `cnibincopy.sh` copying the new multus binary and `multus-daemon` starting and rewriting the CNI config. In this window, CRI-O still has the old 4.13 CNI config (`"type": "multus"`) and invokes the new standalone binary, which reads the old kubeconfig written by 4.13's `entrypoint.sh`. That kubeconfig unconditionally wraps `KUBERNETES_SERVICE_HOST` in brackets (`https://[hostname]:6443`), which Go 1.24.8+ `net/url.Parse()` now rejects for non-IPv6 addresses.

This manifests as `FailedKillPod` errors (500+), stalls the `dns-default` DaemonSet rollout, causes DNS operator degradation, and fails the upgrade. The `gcp-ovn-rt-upgrade-4.14-minor` blocking job has been failing for 5+ consecutive payloads.

## Fix
Reader-side sanitization in `GetK8sClient()`: after loading a kubeconfig via `clientcmd.BuildConfigFromFlags()`, strip brackets from `config.Host` when the bracketed content contains no colons (hostname or IPv4, not IPv6). This is the single code path where the standalone `multus` binary reads the kubeconfig from disk.

This approach is preferred over the CNO init container approach (cluster-network-operator#3000) because:
- Single code change vs. permanent DaemonSet infrastructure
- No fragile sed regex (the init container regex incorrectly strips brackets from IPv6 addresses ending in hex digits a-f)
- Handles any kubeconfig with brackets, not just the specific file path

## Test plan
- [x] Unit tests for `sanitizeBracketedHost()` covering hostname, IPv4, IPv6 (digit-ending and hex-ending), loopback, no-brackets, and empty string
- [x] `go build ./pkg/k8sclient/` passes
- [ ] Verify `gcp-ovn-rt-upgrade-4.14-minor` (4.13-to-4.14 upgrade) passes with this change
- [ ] Verify fresh 4.14 install succeeds (no kubeconfig to sanitize)
- [ ] Verify IPv6 dual-stack clusters preserve bracketed IPv6 addresses

/cc @s1061123 @tsorya

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Kubernetes client configuration to properly handle bracketed hostnames in API server URLs, preventing rejection by the Go runtime.

* **Tests**
  * Added test coverage for bracketed hostname handling in various formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->