### PR TITLE
[release-4.13] Fix server URL in generated kubeconfig

### DIFF
--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -268,7 +268,7 @@ kind: Config
 clusters:
 - name: local
   cluster:
-    server: ${KUBERNETES_SERVICE_PROTOCOL:-https}://[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}
+    server: ${KUBERNETES_SERVICE_PROTOCOL:-https}://$( [[ "${KUBERNETES_SERVICE_HOST}" =~ : ]] && echo "[${KUBERNETES_SERVICE_HOST}]" || echo "${KUBERNETES_SERVICE_HOST}"):${KUBERNETES_SERVICE_PORT}
     $TLS_CFG
 users:
 - name: multus


### PR DESCRIPTION
## Summary

Cherry-pick of the fix from release-4.14 PR #287 (commit 24e7c1dc), adapted for the shell-based entrypoint used in 4.13.

- In 4.13, the multus kubeconfig is generated by `images/entrypoint.sh` (not the Go `thin_entrypoint` used in 4.14+)
- The shell script unconditionally wraps `KUBERNETES_SERVICE_HOST` in square brackets when constructing the API server URL: `https://[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}`
- Go 1.24.8+ (CVE-2025-47912) rejects brackets around non-IPv6 addresses, causing `url.Parse()` to fail with: `host must be a URL or a host:port pair: "https://[api-int.hostname]:6443"`
- This fix conditionally adds brackets only when the host contains a colon (IPv6), matching the behavior of `net.JoinHostPort()` in Go

## Why this is needed

The 4.14 nightly `gcp-ovn-rt-upgrade` job upgrades from 4.13 to 4.14. The 4.13 source cluster hits this bug before the upgrade delivers the fixed 4.14 code, causing `FailedKillPod` errors when CRI-O invokes the multus CNI plugin.

## Test plan
- [ ] Verify kubeconfig generated by entrypoint.sh uses correct URL format for DNS hostname API servers
- [ ] Verify kubeconfig generated by entrypoint.sh still works correctly for IPv6 API server addresses
- [ ] Verify 4.13 -> 4.14 upgrade succeeds without multus CNI failures