### PR TITLE
[release-4.15] OCPBUGS-85252: Fix server url in kubeconfig

### DIFF
--- a/cmd/thin_entrypoint/main.go
+++ b/cmd/thin_entrypoint/main.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -199,7 +200,7 @@ func (o *Options) createKubeConfig(currentFileHash []byte) ([]byte, error) {
 		return nil, fmt.Errorf("template parse error: %v", err)
 	}
 	templateData := map[string]string{
-		"KubeConfigHost":          fmt.Sprintf("%s://[%s]:%s", kubeProtocol, kubeHost, kubePort),
+		"KubeConfigHost":          fmt.Sprintf("%s://%s", kubeProtocol, net.JoinHostPort(kubeHost, kubePort)),
 		"KubeServerTLS":           tlsConfig,
 		"KubeServiceAccountToken": string(saTokenByte),
 	}


### PR DESCRIPTION
This is a manual backport of #300 (which backported #288 / #273 to release-4.16) to release-4.15.

## Summary

- Use `net.JoinHostPort` to properly format the kubeconfig server URL instead of manually wrapping the host in square brackets (`[%s]`).
- The old format always applied IPv6 bracket notation, which produces a malformed URL for IPv4 addresses and hostnames.

## Test plan
- [ ] Verify kubeconfig server URL is well-formed for IPv4, IPv6, and hostname-based clusters