### PR TITLE
OCPBUGS-88546: Update Go directive to be consistent with ART for 4.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gopkg.in/k8snetworkplumbingwg/multus-cni.v4
 
-go 1.21
+go 1.24
 
 require (
 	github.com/blang/semver v3.5.1+incompatible

--- a/pkg/k8sclient/k8sclient.go
+++ b/pkg/k8sclient/k8sclient.go
@@ -205,13 +205,13 @@ func parsePodNetworkObjectName(podnetwork string) (string, string, string, error
 	for i := range allItems {
 		matched := expr.MatchString(allItems[i])
 		if !matched && len([]rune(allItems[i])) > 0 {
-			return "", "", "", logging.Errorf(fmt.Sprintf("parsePodNetworkObjectName: Failed to parse: one or more items did not match comma-delimited format (must consist of lower case alphanumeric characters). Must start and end with an alphanumeric character), mismatch @ '%v'", allItems[i]))
+			return "", "", "", logging.Errorf("parsePodNetworkObjectName: Failed to parse: one or more items did not match comma-delimited format (must consist of lower case alphanumeric characters). Must start and end with an alphanumeric character), mismatch @ '%v'", allItems[i])
 		}
 	}
 
 	if len(netIfName) > 0 {
 		if len(netIfName) > (syscall.IFNAMSIZ-1) || strings.ContainsAny(netIfName, " \t\n\v\f\r/") {
-			return "", "", "", logging.Errorf(fmt.Sprintf("parsePodNetworkObjectName: Failed to parse interface name: must be less than 15 chars and not contain '/' or spaces. interface name '%s'", netIfName))
+			return "", "", "", logging.Errorf("parsePodNetworkObjectName: Failed to parse interface name: must be less than 15 chars and not contain '/' or spaces. interface name '%s'", netIfName)
 		}
 	}
 
@@ -298,7 +298,7 @@ func getKubernetesDelegate(client *ClientInfo, net *types.NetworkSelectionElemen
 		if client != nil {
 			client.Eventf(pod, v1.EventTypeWarning, "NoNetworkFound", errMsg)
 		}
-		return nil, resourceMap, logging.Errorf("getKubernetesDelegate: " + errMsg)
+		return nil, resourceMap, logging.Errorf("getKubernetesDelegate: %s", errMsg)
 	}
 
 	// Get resourceName annotation from NetworkAttachmentDefinition

--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -516,7 +516,7 @@ func delPlugins(exec invoke.Exec, pod *v1.Pod, args *skel.CmdArgs, k8sArgs *type
 
 	// Check if we had any errors, and send them all back.
 	if len(errorstrings) > 0 {
-		return fmt.Errorf(strings.Join(errorstrings, " / "))
+		return fmt.Errorf("%s", strings.Join(errorstrings, " / "))
 	}
 
 	return nil


### PR DESCRIPTION
There is a skew between the Go versions used for building, testing and the Go directive inside the go.mod file. This PR is an effort to bring parity between ART and the component for the `release-4.20` branch.

Changes:
Bump Go directive to `1.24`

Couple of string formatting constraints were found when moving to Go 1.24 which were captured by go vet, fixed them in another commit.