### PR TITLE
OCPBUGS-88546: Update Go directive and build_root_image to be consistent with ART for 4.19

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.22-openshift-4.19
+  tag: rhel-9-release-golang-1.23-openshift-4.19

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gopkg.in/k8snetworkplumbingwg/multus-cni.v4
 
-go 1.21
+go 1.23
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
There is a skew between the Go versions used for building, testing and the Go directive inside the go.mod file. This PR is an effort to bring parity between ART and the component for the `release-4.19` branch.

Changes:
build_root_image.tag: `tag: rhel-9-release-golang-1.23-openshift-4.19`
Bump Go directive to `1.23`