### PR TITLE
OCPBUGS-88546: Update Go directive to be consistent with ART for 4.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gopkg.in/k8snetworkplumbingwg/multus-cni.v4
 
-go 1.21
+go 1.22
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
There is a skew between the Go versions used for building, testing and the Go directive inside the go.mod file. This PR is an effort to bring parity between ART and the component for the `release-4.17` branch.

Changes:
Bump Go directive to `1.22`