### PR TITLE
[release-4.23] Revert "Sort DeviceIDs in GetPodResourceMap for deterministic ordering"

### DIFF
--- a/pkg/checkpoint/checkpoint.go
+++ b/pkg/checkpoint/checkpoint.go
@@ -108,6 +108,5 @@ func (cp *checkpoint) GetPodResourceMap(pod *v1.Pod) (map[string]*types.Resource
 			}
 		}
 	}
-	types.SortDeviceIDs(resourceMap)
 	return resourceMap, nil
 }

--- a/pkg/checkpoint/checkpoint_test.go
+++ b/pkg/checkpoint/checkpoint_test.go
@@ -132,13 +132,12 @@ var _ = Describe("Kubelet checkpoint data read operations", func() {
 			Expect(len(resourceInfo.DeviceIDs)).To(BeEquivalentTo(2))
 		})
 
-		// DeviceIDs are sorted for deterministic order across callers
-		It("should have \"0000:03:02.0\" in deviceIDs[0] (sorted order)", func() {
-			Expect(resourceInfo.DeviceIDs[0]).To(BeEquivalentTo("0000:03:02.0"))
+		It("should have \"0000:03:02.3\" in deviceIDs[0]", func() {
+			Expect(resourceInfo.DeviceIDs[0]).To(BeEquivalentTo("0000:03:02.3"))
 		})
 
-		It("should have \"0000:03:02.3\" in deviceIDs[1] (sorted order)", func() {
-			Expect(resourceInfo.DeviceIDs[1]).To(BeEquivalentTo("0000:03:02.3"))
+		It("should have \"0000:03:02.0\" in deviceIDs[1]", func() {
+			Expect(resourceInfo.DeviceIDs[1]).To(BeEquivalentTo("0000:03:02.0"))
 		})
 	})
 

--- a/pkg/draclient/draclient.go
+++ b/pkg/draclient/draclient.go
@@ -200,7 +200,6 @@ func (d *draClient) GetPodResourceMap(ctx context.Context, pod *v1.Pod, resource
 		}
 	}
 
-	types.SortDeviceIDs(resourceMap)
 	logging.Verbosef("GetPodResourceMap: successfully processed all DRA resources for pod %s/%s, total resources: %d",
 		pod.Namespace, pod.Name, len(resourceMap))
 	return nil

--- a/pkg/kubeletclient/kubeletclient.go
+++ b/pkg/kubeletclient/kubeletclient.go
@@ -140,7 +140,6 @@ func (rc *kubeletClient) GetPodResourceMap(pod *v1.Pod) (map[string]*types.Resou
 			}
 		}
 	}
-	types.SortDeviceIDs(resourceMap)
 	return resourceMap, nil
 }
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -17,7 +17,6 @@ package types
 
 import (
 	"net"
-	"sort"
 
 	"github.com/containernetworking/cni/pkg/types"
 	cni100 "github.com/containernetworking/cni/pkg/types/100"
@@ -175,16 +174,6 @@ type K8sArgs struct {
 type ResourceInfo struct {
 	Index     int
 	DeviceIDs []string
-}
-
-// SortDeviceIDs sorts DeviceIDs in each ResourceInfo in place so that device
-// order is deterministic across GetPodResourceMap callers (e.g. Multus and OVN-Kubernetes).
-func SortDeviceIDs(resourceMap map[string]*ResourceInfo) {
-	for _, rInfo := range resourceMap {
-		if rInfo.DeviceIDs != nil {
-			sort.Strings(rInfo.DeviceIDs)
-		}
-	}
 }
 
 // ResourceClient provides a kubelet Pod resource handle


### PR DESCRIPTION
This reverts commit 1f27f0e3311e7f7f616e025c9ee841a102c39101 (PR #1481).

PR #1481 sorted all device IDs pod-wide per resourceName before Multus assigned them to NADs by annotation order. That made ordering deterministic for single-container UDN (OVN-Kubernetes) setups, but it regressed multi-container pods where each container receives its own VF for the same resourceName.

Kubelet allocates devices per container, yet Multus still flattens them into one list and hands them out sequentially by NAD index. Sorting that flattened list breaks the implicit mapping between a container's allocated VF and the NAD intended for that container, causing network-status PCI addresses to disagree with PCIDEVICE_* env vars (from CDI) after pod restart.

Remove pod-wide sorting from the kubelet, checkpoint, and DRA paths until per-container allocation/sorting is in place.